### PR TITLE
Fix issue #6: [Compat] Codex v0.128.0: Turn metadata format changes (ASCII JSON escaping + new timestamp field)

### DIFF
--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(currentDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const root = resolve(currentDir, "..");
+const binDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(binDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -192,7 +192,13 @@ fn handle_event_msg(
             if turn_id.is_empty() {
                 return;
             }
-            let started_at = entry.timestamp.as_deref().and_then(parse_timestamp_secs);
+            // Prefer turn_start_timestamp from payload (added in Codex v0.128.0 via #19473).
+            // Fall back to the outer JSONL line timestamp for sessions captured before that.
+            let started_at = payload
+                .get("turn_start_timestamp")
+                .and_then(|v| v.as_f64())
+                .map(|v| v as u64)
+                .or_else(|| entry.timestamp.as_deref().and_then(parse_timestamp_secs));
             let mut turn = CodexTurn::new(turn_id.clone());
             turn.started_at = started_at;
             turns.insert(turn_id.clone(), turn);
@@ -893,5 +899,42 @@ mod tests {
         assert_eq!(turns[0].collab_spawns[0].agent_nickname, "Noether");
         assert_eq!(turns[0].tool_calls.len(), 1);
         assert_eq!(turns[0].tool_calls[0].kind, ToolKind::SpawnAgent);
+    }
+
+    // Codex v0.128.0 (#19473): task_started now includes turn_start_timestamp in the payload.
+    // It should be used as started_at in preference to the outer JSONL line timestamp.
+    #[test]
+    fn turn_start_timestamp_in_payload_is_used_as_started_at() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            // turn_start_timestamp = 1746000050.0 (earlier than outer line timestamp 1746000060)
+            r#"{"timestamp":"2026-04-30T10:01:00Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","turn_start_timestamp":1746000050.0}}"#,
+            r#"{"timestamp":"2026-04-30T10:02:00Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746000120.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        // started_at should come from turn_start_timestamp (1746000050), not the line timestamp
+        assert_eq!(turns[0].started_at, Some(1746000050));
+    }
+
+    // Codex v0.128.0 (#19620): turn metadata headers are now ASCII-escaped JSON.
+    // serde_json handles \uXXXX sequences natively; verify non-ASCII in payloads parses correctly.
+    #[test]
+    fn ascii_escaped_unicode_in_task_started_payload_is_parsed_correctly() {
+        // Chinese characters ASCII-escaped as Codex v0.128.0 emits
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:01:00Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","turn_start_timestamp":1746000050.0}}"#,
+            "{\"timestamp\":\"2026-04-30T10:01:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"\\u4e2d\\u6587\"}}",
+            r#"{"timestamp":"2026-04-30T10:02:00Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746000120.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        // The ASCII-escaped Unicode must be decoded to its actual UTF-8 string value
+        assert_eq!(turns[0].user_message.as_deref(), Some("\u{4e2d}\u{6587}"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #6

Adds compatibility with Codex v0.128.0, which introduced two breaking changes to turn metadata format.

## Changes

### 1. `turn_start_timestamp` field support (`src-tauri/src/parser/turn.rs`)

Codex v0.128.0 (PR #19473) added a `turn_start_timestamp` field to `task_started` event payloads, recording the precise moment a turn began. The parser now prefers this value as `started_at` over the outer JSONL line timestamp. Sessions captured before v0.128.0 fall back gracefully to the line timestamp.

### 2. ASCII-escaped JSON compatibility (`src-tauri/src/parser/turn.rs`)

Codex v0.128.0 (PR #19620) changed turn metadata serialization to use ASCII-safe JSON escaping (`\uXXXX` for non-ASCII characters). Since the parser uses `serde_json::from_str` throughout, `\uXXXX` sequences are decoded transparently — no code change was required. A regression test is added to document this expectation and catch any future regression.

### 3. Lint fix (`bin/codex-trace.mjs`)

Renames `__dirname` to `currentDir` to resolve a pre-existing `no-underscore-dangle` lint warning.

## Tests

Two new Rust unit tests in `parser::turn::tests`:

- `turn_start_timestamp_in_payload_is_used_as_started_at` — asserts the payload value is used when present, not the line timestamp
- `ascii_escaped_unicode_in_task_started_payload_is_parsed_correctly` — asserts `\uXXXX`-escaped Unicode decodes to correct UTF-8

All Rust tests and frontend tests pass.
