### PR TITLE
Fix issue #8: [Compat] Codex v0.128.0: External agent session format changes (new end marker, ai-title field)

### DIFF
--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(currentDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const root = resolve(currentDir, "..");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -98,6 +98,7 @@ export interface CodexSession {
   total_tokens: TokenInfo | null;
   thread_name: string | null;
   spawned_worker_ids: string[];
+  ai_title: string | null;
   path: string;
 }
 
@@ -123,6 +124,7 @@ export interface CodexSessionInfo {
   worker_role: string | null;
   spawned_worker_ids: string[];
   date_group: string;
+  ai_title: string | null;
 }
 
 export interface SettingsResponse {

--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -32,6 +32,8 @@ pub struct CodexSessionInfo {
     pub spawned_worker_ids: Vec<String>,
     /// "YYYY/MM/DD" derived from the file path
     pub date_group: String,
+    /// Optional AI-generated title from external agent sessions (Codex v0.128.0+)
+    pub ai_title: Option<String>,
 }
 
 /// Scan a sessions directory recursively for all rollout-*.jsonl files.
@@ -136,6 +138,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         is_external_worker,
         worker_nickname,
         worker_role,
+        ai_title,
     ) = match entry.entry_type.as_str() {
         "session_meta" => {
             let id = str_field(payload, "id");
@@ -155,6 +158,11 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .and_then(|s| s.get("subagent"))
                 .is_some();
             let (worker_nickname, worker_role) = worker_metadata(payload);
+            let ai_title = payload
+                .get("ai-title")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
             (
                 id,
                 start_time,
@@ -166,6 +174,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 is_external_worker,
                 worker_nickname,
                 worker_role,
+                ai_title,
             )
         }
         "session_meta_root" => {
@@ -177,7 +186,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
             (
-                id, start_time, None, None, None, git_branch, None, false, None, None,
+                id, start_time, None, None, None, git_branch, None, false, None, None, None,
             )
         }
         _ => return None,
@@ -197,6 +206,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
     let mut pending_spawn_call_ids: std::collections::HashSet<String> =
         std::collections::HashSet::new();
     let mut is_ongoing = true;
+    let mut has_session_end = false;
 
     for line in lines {
         if line.trim().is_empty() {
@@ -209,6 +219,16 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
 
         let t = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
         match t {
+            "session_end" => {
+                has_session_end = true;
+                is_ongoing = false;
+                if end_time.is_none() {
+                    end_time = v
+                        .get("timestamp")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                }
+            }
             "event_msg" => {
                 let pt = v
                     .get("payload")
@@ -218,12 +238,16 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 match pt {
                     "task_started" => {
                         turn_count += 1;
-                        is_ongoing = true;
+                        if !has_session_end {
+                            is_ongoing = true;
+                        }
                         end_time = None;
                     }
                     "user_message" if turn_count == 0 => {
                         turn_count += 1;
-                        is_ongoing = true;
+                        if !has_session_end {
+                            is_ongoing = true;
+                        }
                         end_time = None;
                     }
                     "task_complete" => {
@@ -335,7 +359,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
     // Validate with file mtime: sessions last modified more than 60 seconds ago
     // cannot be actively processing a turn, regardless of missing task_complete events.
     // Many older CLI versions didn't emit task_complete, causing false positives otherwise.
-    if is_ongoing {
+    if is_ongoing && !has_session_end {
         const ONGOING_THRESHOLD_SECS: u64 = 60;
         if let Ok(metadata) = fs::metadata(path) {
             if let Ok(modified) = metadata.modified() {
@@ -370,6 +394,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         worker_role,
         spawned_worker_ids,
         date_group,
+        ai_title,
     })
 }
 
@@ -563,5 +588,81 @@ mod tests {
         assert_eq!(session.turn_count, 2);
         assert!(!session.is_ongoing);
         assert!(session.end_time.is_some());
+    }
+
+    #[test]
+    fn discover_sessions_reads_ai_title() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/04/30");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let session_path = day_dir.join("rollout-2026-04-30T10-00-00-aititle.jsonl");
+        std::fs::write(
+            &session_path,
+            [
+                r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"aititle-session","timestamp":"2026-04-30T10:00:00Z","ai-title":"Refactor the auth module"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007202.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions.iter().find(|s| s.id == "aititle-session").unwrap();
+        assert_eq!(
+            session.ai_title.as_deref(),
+            Some("Refactor the auth module")
+        );
+    }
+
+    #[test]
+    fn discover_sessions_session_end_marks_not_ongoing() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/04/30");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let session_path = day_dir.join("rollout-2026-04-30T10-01-00-ended.jsonl");
+        std::fs::write(
+            &session_path,
+            [
+                r#"{"timestamp":"2026-04-30T10:01:00Z","type":"session_meta","payload":{"id":"ended-session","timestamp":"2026-04-30T10:01:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007262.0}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:03Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions.iter().find(|s| s.id == "ended-session").unwrap();
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn discover_sessions_session_end_overrides_ongoing_turn() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/04/30");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let session_path = day_dir.join("rollout-2026-04-30T10-02-00-endmarker.jsonl");
+        std::fs::write(
+            &session_path,
+            [
+                r#"{"timestamp":"2026-04-30T10:02:00Z","type":"session_meta","payload":{"id":"endmarker-session","timestamp":"2026-04-30T10:02:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:02:02Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "endmarker-session")
+            .unwrap();
+        assert!(!session.is_ongoing);
     }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -33,6 +33,7 @@ pub struct CodexSession {
     pub thread_name: Option<String>,
     pub spawned_worker_ids: Vec<String>,
     pub path: String,
+    pub ai_title: Option<String>,
 }
 
 /// Parse a Codex JSONL session file into a CodexSession.
@@ -75,6 +76,7 @@ fn parse_session_inner(
         thread_name: None,
         spawned_worker_ids: Vec::new(),
         path: path.to_string_lossy().to_string(),
+        ai_title: None,
     };
 
     // Parse session_meta from first matching entry
@@ -91,6 +93,10 @@ fn parse_session_inner(
             _ => {}
         }
     }
+
+    // Check for explicit session_end marker (Codex v0.128.0+).
+    // When present the session is definitively closed regardless of file freshness.
+    let has_session_end = entries.iter().any(|e| e.entry_type == "session_end");
 
     // Build turns from remaining entries
     let mut turns = build_turns(&entries);
@@ -111,6 +117,8 @@ fn parse_session_inner(
     // modified within 60 seconds (same threshold as source repo). Sessions older
     // than that have no live CLI writing to them — task_complete was simply missed
     // (crash, kill, older CLI that never emitted the event).
+    // A session_end marker (v0.128.0+) overrides both heuristics: the session
+    // is definitively closed even if the file is still fresh.
     let turn_ongoing = turns
         .last()
         .map(|t| t.status == super::turn::TurnStatus::Ongoing)
@@ -124,11 +132,12 @@ fn parse_session_inner(
                 .unwrap_or(true)
         })
         .unwrap_or(true);
-    let is_ongoing = turn_ongoing && file_fresh;
+    let is_ongoing = !has_session_end && turn_ongoing && file_fresh;
 
-    // If the file is stale and the last turn never got a completion event,
-    // mark it as Aborted so the UI doesn't show an ongoing indicator.
-    if turn_ongoing && !file_fresh {
+    // If the file is stale (or session_end present) and the last turn never got
+    // a completion event, mark it as Aborted so the UI doesn't show an ongoing
+    // indicator.
+    if turn_ongoing && (!file_fresh || has_session_end) {
         if let Some(last) = turns.last_mut() {
             last.status = TurnStatus::Aborted;
         }
@@ -237,6 +246,12 @@ fn parse_session_meta_new(session: &mut CodexSession, payload: &Value, _raw: &Va
     session.originator = opt_str(payload, "originator");
     session.cli_version = opt_str(payload, "cli_version");
     session.model_provider = opt_str(payload, "model_provider");
+    // ai-title is an optional field added in Codex v0.128.0 for external agent sessions
+    session.ai_title = payload
+        .get("ai-title")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
 
     if let Some(git) = payload.get("git") {
         session.git = Some(GitInfo {
@@ -414,5 +429,90 @@ mod tests {
             nested_worker_session.turns[0].tool_calls[0].output,
             Some("nested output".to_string())
         );
+    }
+
+    #[test]
+    fn parse_session_reads_ai_title_from_session_meta() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-04-30T10-00-00-ext.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"ext-session","timestamp":"2026-04-30T10:00:00Z","ai-title":"Fix the login bug"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007202.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.ai_title.as_deref(), Some("Fix the login bug"));
+        assert_eq!(session.id, "ext-session");
+    }
+
+    #[test]
+    fn parse_session_end_marker_closes_session() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-04-30T10-01-00-ended.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-30T10:01:00Z","type":"session_meta","payload":{"id":"ended-session","timestamp":"2026-04-30T10:01:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007262.0}}"#,
+                r#"{"timestamp":"2026-04-30T10:01:03Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn parse_session_end_marker_overrides_ongoing_turn() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-04-30T10-02-00-endmarker.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-30T10:02:00Z","type":"session_meta","payload":{"id":"endmarker-session","timestamp":"2026-04-30T10:02:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:02:02Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        // session_end overrides the ongoing turn — session must not appear live
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn parse_session_unknown_record_types_are_skipped() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-04-30T10-03-00-unknown.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-30T10:03:00Z","type":"session_meta","payload":{"id":"unknown-types-session","timestamp":"2026-04-30T10:03:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:03:01Z","type":"future_record_type_v999","payload":{"data":"some future data"}}"#,
+                r#"{"timestamp":"2026-04-30T10:03:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:03:03Z","type":"another_unknown_type","payload":{}}"#,
+                r#"{"timestamp":"2026-04-30T10:03:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007384.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "unknown-types-session");
+        assert_eq!(session.turns.len(), 1);
+        assert!(!session.is_ongoing);
     }
 }

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -29,6 +29,7 @@ function makeSession(overrides: Partial<CodexSession> = {}): CodexSession {
     thread_name: null,
     spawned_worker_ids: [],
     path: "/sessions/2026/04/26/rollout-abc.jsonl",
+    ai_title: null,
     ...overrides,
   };
 }

--- a/src/components/SidebarTree.test.tsx
+++ b/src/components/SidebarTree.test.tsx
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     worker_role: null,
     spawned_worker_ids: [],
     date_group: "2026/04/26",
+    ai_title: null,
     ...overrides,
   };
 }

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -71,6 +71,7 @@ function makeWorkerSession(toolCalls: CodexToolCall[]): CodexSession {
     thread_name: "Worker thread",
     spawned_worker_ids: [],
     path: "/tmp/worker.jsonl",
+    ai_title: null,
   };
 }
 

--- a/src/components/WorkerPanel.test.tsx
+++ b/src/components/WorkerPanel.test.tsx
@@ -74,6 +74,7 @@ function makeSession(toolCalls: CodexToolCall[]): CodexSession {
     thread_name: "Same parent title",
     spawned_worker_ids: [],
     path: "/tmp/worker.jsonl",
+    ai_title: null,
   };
 }
 

--- a/src/lib/sessionDisplay.test.ts
+++ b/src/lib/sessionDisplay.test.ts
@@ -23,6 +23,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     worker_role: null,
     spawned_worker_ids: [],
     date_group: "2026/04/26",
+    ai_title: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes compatibility with Codex v0.128.0, which introduced external agent session support across three PRs (#19895, #20261, #20284), changing the session file format in three ways:

1. A new **`ai-title`** field in `session_meta` payload for external agent sessions
2. A new **`session_end`** record written at session close (explicit end marker)
3. **Background import** means session files may be partially written before the end marker appears

## Changes

### 1. `ai-title` field support

`src-tauri/src/parser/session.rs` and `src-tauri/src/parser/discover.rs` now read `ai-title` from the `session_meta` payload and expose it as `ai_title: Option<String>` on `CodexSession` and `CodexSessionInfo`. The TypeScript interface in `shared/types.ts` is updated to match.

### 2. `session_end` record handling

Both the quick scanner (`discover.rs`) and the full parser (`session.rs`) now detect a `session_end` record and treat it as a definitive close signal:

- `is_ongoing` is forced to `false` regardless of file freshness
- A `task_started` or `user_message` event seen **after** a `session_end` cannot re-set `is_ongoing` to `true` (guards the background import race)
- An ongoing turn at the time `session_end` appears is marked `Aborted` so the UI shows no live indicator
- The file mtime heuristic is bypassed when `session_end` is present (no false "stale = closed" penalty for fresh end-marker sessions)

### 3. Unknown record type handling

Unknown top-level record types (e.g. any future format additions) already fall through to `_ => {}` in both `build_turns` and `scan_session_file`. A new regression test (`parse_session_unknown_record_types_are_skipped`) documents and enforces this invariant.

### 4. Test fixture updates

Five frontend test files had mock `CodexSession` / `CodexSessionInfo` objects that needed `ai_title: null` added to satisfy the updated TypeScript interface.

### 5. Lint fix

`bin/codex-trace.mjs`: renamed `__dirname` → `currentDir` to resolve the `no-underscore-dangle` warning.

## Tests

New Rust unit tests in `parser::session::tests`:
- `parse_session_reads_ai_title_from_session_meta`
- `parse_session_end_marker_closes_session`
- `parse_session_end_marker_overrides_ongoing_turn`
- `parse_session_unknown_record_types_are_skipped`

New Rust unit tests in `parser::discover::tests`:
- `discover_sessions_reads_ai_title`
- `discover_sessions_session_end_marks_not_ongoing`
- `discover_sessions_session_end_overrides_ongoing_turn`

All 47 Rust unit tests pass (`cargo test --lib`).
All 122 frontend tests pass (`npx vitest run`).
`cargo clippy -- -D warnings` passes with zero warnings.
`npx tsc --noEmit` passes with zero errors.
`npx oxlint` passes with zero warnings/errors.

## Closes

Closes #8
