### PR TITLE
Fix issue #12: [Compat] Codex v0.128.0: Token usage fields added to turn tracing spans

### DIFF
--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -267,6 +267,21 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                                     .and_then(|v| v.as_str())
                                     .map(|s| s.to_string())
                             });
+                        // Codex v0.128.0: task_complete may carry prompt_tokens/completion_tokens/total_tokens.
+                        // Use as fallback when no token_count event was seen.
+                        if total_tokens.is_none() {
+                            total_tokens = payload
+                                .get("total_tokens")
+                                .and_then(|v| v.as_u64())
+                                .or_else(|| {
+                                    let p =
+                                        payload.get("prompt_tokens").and_then(|v| v.as_u64())?;
+                                    let c = payload
+                                        .get("completion_tokens")
+                                        .and_then(|v| v.as_u64())?;
+                                    Some(p + c)
+                                });
+                        }
                     }
                     "turn_aborted" => {
                         is_ongoing = false;
@@ -664,5 +679,30 @@ mod tests {
             .find(|s| s.id == "endmarker-session")
             .unwrap();
         assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn reads_total_tokens_from_task_complete_v0128() {
+        // Codex v0.128.0 adds prompt_tokens/completion_tokens/total_tokens to task_complete.
+        // The discover scanner should use these as a fallback when no token_count event exists.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/04/30");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let session_path = day_dir.join("rollout-2026-04-30T10-00-00-s1.jsonl");
+        std::fs::write(
+            &session_path,
+            [
+                r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-04-30T10:00:00Z"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-30T10:00:10Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007210.0,"prompt_tokens":1500,"completion_tokens":300,"total_tokens":1800}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions.iter().find(|s| s.id == "s1").unwrap();
+
+        assert_eq!(session.total_tokens, Some(1800));
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -307,6 +307,28 @@ fn handle_event_msg(
                     .map(|v| v as u64)
                     .or_else(|| entry.timestamp.as_deref().and_then(parse_timestamp_secs));
                 turn.duration_ms = payload.get("duration_ms").and_then(|v| v.as_u64());
+                // Codex v0.128.0 adds prompt_tokens/completion_tokens/total_tokens to task_complete.
+                // Use these only when no richer token_count event has already populated the turn.
+                if turn.total_tokens.is_none() {
+                    let prompt_tokens = payload.get("prompt_tokens").and_then(|v| v.as_u64());
+                    let completion_tokens =
+                        payload.get("completion_tokens").and_then(|v| v.as_u64());
+                    let total = payload
+                        .get("total_tokens")
+                        .and_then(|v| v.as_u64())
+                        .or_else(|| prompt_tokens.zip(completion_tokens).map(|(p, c)| p + c));
+                    if let Some(total_tokens) = total {
+                        turn.total_tokens = Some(TokenInfo {
+                            input_tokens: prompt_tokens.unwrap_or(0),
+                            cached_input_tokens: 0,
+                            output_tokens: completion_tokens.unwrap_or(0),
+                            reasoning_output_tokens: 0,
+                            total_tokens,
+                            context_window_tokens: None,
+                            model_context_window: 0,
+                        });
+                    }
+                }
             }
         }
 
@@ -936,5 +958,28 @@ mod tests {
         assert_eq!(turns.len(), 1);
         // The ASCII-escaped Unicode must be decoded to its actual UTF-8 string value
         assert_eq!(turns[0].user_message.as_deref(), Some("\u{4e2d}\u{6587}"));
+    }
+
+    #[test]
+    fn reads_token_usage_from_task_complete_v0128() {
+        // Codex v0.128.0 adds prompt_tokens/completion_tokens/total_tokens to task_complete.
+        // These should populate turn.total_tokens when no prior token_count event exists.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:10Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746007210.0,"prompt_tokens":1500,"completion_tokens":300,"total_tokens":1800}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        let tokens = turns[0]
+            .total_tokens
+            .as_ref()
+            .expect("token info from task_complete");
+        assert_eq!(tokens.input_tokens, 1500);
+        assert_eq!(tokens.output_tokens, 300);
+        assert_eq!(tokens.total_tokens, 1800);
+        assert_eq!(tokens.cached_input_tokens, 0);
+        assert_eq!(tokens.context_window_tokens, None);
     }
 }


### PR DESCRIPTION
Fixes #12

Codex v0.128.0 (PR #19432) adds `prompt_tokens`, `completion_tokens`, and `total_tokens` as attributes on the `task_complete` tracing span emitted at the end of each turn.

## Changes

- **`turn.rs`**: Read the three token fields from `task_complete` payloads and populate `turn.total_tokens` when no richer `token_count` event has already set it. Falls back to summing `prompt + completion` when `total_tokens` is absent.
- **`discover.rs`**: Apply the same fallback in the session-list scanner so that the aggregate token count on `CodexSessionInfo` is populated from `task_complete` for sessions produced by v0.128.0.
- **`bin/codex-trace.mjs`**: Fix pre-existing no-underscore-dangle lint warning by renaming `__dirname` to `dirName`.

## Tests Added

- `reads_token_usage_from_task_complete_v0128` (turn.rs)
- `task_complete_tokens_do_not_override_token_count_event` (turn.rs)
- `reads_total_tokens_from_task_complete_v0128` (discover.rs)
