### PR TITLE
Fix issue #11: [Compat] Codex v0.128.0: Cancelled inference streams now emit new trace events

### DIFF
--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
+const binDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(binDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const binDir = dirname(fileURLToPath(import.meta.url));
-const root = resolve(binDir, "..");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -69,7 +69,7 @@ export interface CodexTurn {
   started_at: number | null;
   completed_at: number | null;
   duration_ms: number | null;
-  status: "complete" | "aborted" | "ongoing" | "error";
+  status: "complete" | "aborted" | "cancelled" | "ongoing" | "error";
   user_message: string | null;
   agent_messages: AgentMessage[];
   tool_calls: CodexToolCall[];

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -11,6 +11,7 @@ use super::toolcall::{ToolCall, ToolCallBuilder};
 pub enum TurnStatus {
     Complete,
     Aborted,
+    Cancelled,
     Ongoing,
     Error,
 }
@@ -321,6 +322,28 @@ fn handle_event_msg(
                     .get("reason")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
+                turn.completed_at = payload
+                    .get("completed_at")
+                    .and_then(|v| v.as_f64())
+                    .map(|v| v as u64)
+                    .or_else(|| entry.timestamp.as_deref().and_then(parse_timestamp_secs));
+                turn.duration_ms = payload.get("duration_ms").and_then(|v| v.as_u64());
+            }
+        }
+
+        "inference_stream_cancelled" => {
+            let turn_id_field = payload
+                .get("turn_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or(current_turn_id.as_deref().unwrap_or(""))
+                .to_string();
+            let target_id = if !turn_id_field.is_empty() {
+                turn_id_field
+            } else {
+                current_turn_id.clone().unwrap_or_default()
+            };
+            if let Some(turn) = turns.get_mut(&target_id) {
+                turn.status = TurnStatus::Cancelled;
                 turn.completed_at = payload
                     .get("completed_at")
                     .and_then(|v| v.as_f64())
@@ -893,5 +916,66 @@ mod tests {
         assert_eq!(turns[0].collab_spawns[0].agent_nickname, "Noether");
         assert_eq!(turns[0].tool_calls.len(), 1);
         assert_eq!(turns[0].tool_calls[0].kind, ToolKind::SpawnAgent);
+    }
+
+    #[test]
+    fn inference_stream_cancelled_marks_turn_cancelled() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"sess-1","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"Working on it...","phase":"commentary"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:03Z","type":"event_msg","payload":{"type":"inference_stream_cancelled","turn_id":"turn-1","completed_at":1746007203.0,"duration_ms":2000}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Cancelled);
+        assert_eq!(turns[0].completed_at, Some(1746007203));
+        assert_eq!(turns[0].duration_ms, Some(2000));
+    }
+
+    #[test]
+    fn inference_stream_cancelled_falls_back_to_entry_timestamp() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"sess-2","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:05Z","type":"event_msg","payload":{"type":"inference_stream_cancelled","turn_id":"turn-2"}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Cancelled);
+        assert!(turns[0].completed_at.is_some());
+    }
+
+    #[test]
+    fn inference_stream_cancelled_uses_current_turn_when_no_turn_id() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"sess-3","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-3"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:04Z","type":"event_msg","payload":{"type":"inference_stream_cancelled"}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Cancelled);
+    }
+
+    #[test]
+    fn unknown_event_types_are_ignored_gracefully() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-30T10:00:00Z","type":"session_meta","payload":{"id":"sess-4","timestamp":"2026-04-30T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-4"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:02Z","type":"event_msg","payload":{"type":"some_future_unknown_event","data":"whatever"}}"#,
+            r#"{"timestamp":"2026-04-30T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-4","completed_at":1746007203.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Complete);
     }
 }

--- a/src/components/TurnList.tsx
+++ b/src/components/TurnList.tsx
@@ -21,6 +21,13 @@ interface TurnListProps {
   onSelectTurn: (index: number) => void;
 }
 
+function statusIcon(status: CodexTurn["status"]): string {
+  if (status === "complete") return "✓";
+  if (status === "aborted") return "✗";
+  if (status === "cancelled") return "⊘";
+  return "!";
+}
+
 export function TurnList({ turns, selectedIndex, onSelectTurn }: TurnListProps) {
   const listRef = useAutoScroll<HTMLDivElement>(turns.length);
   const selectedRef = useScrollToSelected(selectedIndex);
@@ -160,7 +167,7 @@ export function TurnList({ turns, selectedIndex, onSelectTurn }: TurnListProps) 
                 <div className="message__stats">
                   {turn.status !== "ongoing" && (
                     <span className={`message__stat turn-list__status--${turn.status}`}>
-                      {turn.status === "complete" ? "✓" : turn.status === "aborted" ? "✗" : "!"}
+                      {statusIcon(turn.status)}
                     </span>
                   )}
                   {(turn.total_tokens?.total_tokens ?? 0) > 0 && (


### PR DESCRIPTION
## Summary

Fixes compatibility with Codex v0.128.0 which introduced new trace events emitted when an inference stream is cancelled.

Fixes #11
