### PR TITLE
[#50]: Guard /autoreview→/approve slash command rename against parser regressions

### DIFF
--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -1486,4 +1486,34 @@ mod tests {
         assert_eq!(tool.mcp_tool.as_deref(), Some("github_get_pr_info"));
         assert_eq!(tool.output.as_deref(), Some("PR #7"));
     }
+
+    // Codex v0.129.0 (PR #21034): /approvals retired; /autoreview renamed to /approve.
+    // codex-trace stores user_message verbatim — no pattern matching on command names —
+    // so the legacy /autoreview and the new /approve are captured identically, and
+    // /approvals entries from older sessions parse without errors or special treatment.
+    #[test]
+    fn slash_command_rename_autoreview_to_approve_stored_verbatim() {
+        let make_entries = |cmd: &str| -> Vec<RawEntry> {
+            let user_msg_line = format!(
+                r#"{{"timestamp":"2026-05-07T10:00:02Z","type":"event_msg","payload":{{"type":"user_message","message":"{cmd}"}}}}"#
+            );
+            entries(&[
+                r#"{"timestamp":"2026-05-07T10:00:00Z","type":"session_meta","payload":{"id":"s-cmd","timestamp":"2026-05-07T10:00:00Z","cli_version":"0.129.0"}}"#,
+                r#"{"timestamp":"2026-05-07T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                &user_msg_line,
+                r#"{"timestamp":"2026-05-07T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746604803.0}}"#,
+            ])
+        };
+
+        for cmd in &["/autoreview", "/approve", "/approvals"] {
+            let turns = build_turns(&make_entries(cmd));
+            assert_eq!(turns.len(), 1, "expected 1 turn for command {cmd}");
+            assert_eq!(
+                turns[0].user_message.as_deref(),
+                Some(*cmd),
+                "user_message must equal the raw command string for {cmd}"
+            );
+            assert_eq!(turns[0].status, TurnStatus::Complete);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #50

## Summary

Codex v0.129.0 (PR #21034) retired the `/approvals` slash command and renamed `/autoreview` to `/approve` in the TUI. This PR confirms codex-trace is unaffected and guards against future regressions.

## What changed

Added a regression-guard test in `src-tauri/src/parser/turn.rs` that explicitly verifies all three slash command variants (`/autoreview`, `/approve`, `/approvals`) are stored verbatim in `CodexTurn.user_message` without any pattern matching or special treatment.

## Why no code change was needed

codex-trace stores user messages as raw strings — the `message` field from `event_msg` payloads is captured as-is into `CodexTurn.user_message` with no parsing or matching on command names. This means:

- `/autoreview` (pre-v0.129.0) and `/approve` (v0.129.0+) are already treated identically
- `/approvals` entries from older sessions parse correctly and are simply stored as user message text
- No display logic or pattern matching keys on these command names

The test documents this invariant explicitly, matching the compat-test pattern established throughout the parser test suite (e.g. `v0129_removed_item_file_change_and_output_delta_events_ignored_gracefully`, `v0130_startup_banner_research_preview_removal_does_not_affect_session_parsing`).

## Test results

- All 92 Rust unit tests pass (including new `slash_command_rename_autoreview_to_approve_stored_verbatim`)
- All 122 frontend tests pass
- `cargo clippy -- -D warnings`: clean
- `npx oxfmt --check` + `npx oxlint` + `npx tsc --noEmit`: clean
