### PR TITLE
fix(parser): support new_session_id in collab_agent_spawn_end for Codex v0.131.0

### DIFF
--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -326,9 +326,12 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                             .map(|s| s.to_string());
                     }
                     "collab_agent_spawn_end" => {
+                        // v0.131.0+ (PR #22268): field renamed new_thread_id → new_session_id
                         if let Some(new_id) = v
                             .get("payload")
-                            .and_then(|p| p.get("new_thread_id"))
+                            .and_then(|p| {
+                                p.get("new_thread_id").or_else(|| p.get("new_session_id"))
+                            })
                             .and_then(|v| v.as_str())
                         {
                             push_unique(&mut spawned_worker_ids, new_id.to_string());
@@ -869,5 +872,46 @@ mod tests {
         let session = sessions.iter().find(|s| s.id == "s1").unwrap();
 
         assert_eq!(session.total_tokens, Some(1800));
+    }
+
+    // Codex v0.131.0 (PR #22268): collab_agent_spawn_end event renamed new_thread_id → new_session_id.
+    // Verify the discover scanner reads new_session_id when new_thread_id is absent.
+    #[test]
+    fn discover_sessions_links_collab_spawn_end_event_v0131_new_session_id() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/05/18");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let parent_path = day_dir.join("rollout-2026-05-18T10-00-00-parent-v131.jsonl");
+        std::fs::write(
+            &parent_path,
+            [
+                r#"{"timestamp":"2026-05-18T10:00:00Z","type":"session_meta","payload":{"id":"parent-v131","timestamp":"2026-05-18T10:00:00Z","cli_version":"0.131.0","source":"cli"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","arguments":"{\"agent_type\":\"worker\",\"message\":\"Gather data\"}","call_id":"call_spawn_v131"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:03Z","type":"event_msg","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_v131","sender_session_id":"parent-v131","new_session_id":"worker-v131","new_agent_nickname":"Hypatia","new_agent_role":"worker","prompt":"Gather data","status":"pending_init"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_spawn_v131","output":"{\"agent_id\":\"worker-v131\",\"nickname\":\"Hypatia\"}"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562405.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let child_path = day_dir.join("rollout-2026-05-18T10-00-09-worker-v131.jsonl");
+        std::fs::write(
+            &child_path,
+            r#"{"timestamp":"2026-05-18T10:00:09Z","type":"session_meta","payload":{"id":"worker-v131","timestamp":"2026-05-18T10:00:09Z","cli_version":"0.131.0","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent-v131","depth":1,"agent_nickname":"Hypatia","agent_role":"worker"}}}}}"#,
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let parent = sessions.iter().find(|s| s.id == "parent-v131").unwrap();
+        let child = sessions.iter().find(|s| s.id == "worker-v131").unwrap();
+
+        assert_eq!(parent.spawned_worker_ids, vec!["worker-v131"]);
+        assert!(child.is_external_worker);
+        assert!(child.is_inline_worker);
+        assert_eq!(child.worker_nickname.as_deref(), Some("Hypatia"));
+        assert_eq!(child.worker_role.as_deref(), Some("worker"));
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -463,7 +463,13 @@ fn handle_event_msg(
                 // Record collab spawn metadata
                 if let Some(turn) = turns.get_mut(tid) {
                     let call_id = str_field(payload, "call_id");
-                    let new_thread_id = str_field(payload, "new_thread_id");
+                    // v0.131.0+ (PR #22268): field renamed new_thread_id → new_session_id
+                    let new_thread_id = payload
+                        .get("new_thread_id")
+                        .or_else(|| payload.get("new_session_id"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
                     let agent_nickname = str_field(payload, "new_agent_nickname");
                     let agent_role = str_field(payload, "new_agent_role");
                     let model = payload
@@ -1636,5 +1642,28 @@ mod tests {
         assert_eq!(user_tool.kind, ToolKind::McpTool);
         assert_eq!(user_tool.mcp_server.as_deref(), Some("github"));
         assert_eq!(user_tool.mcp_tool.as_deref(), Some("get_pr_info"));
+    }
+
+    // Codex v0.131.0 (PR #22268): collab_agent_spawn_end event payload field renamed
+    // new_thread_id → new_session_id. Verify the parser reads new_session_id as a fallback.
+    #[test]
+    fn links_spawn_agent_from_collab_spawn_end_with_new_session_id() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-18T10:00:00Z","type":"session_meta","payload":{"id":"parent-sess","timestamp":"2026-05-18T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-05-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-18T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","arguments":"{\"agent_type\":\"worker\",\"message\":\"Do work\"}","call_id":"call_spawn_v131"}}"#,
+            r#"{"timestamp":"2026-05-18T10:00:03Z","type":"event_msg","payload":{"type":"collab_agent_spawn_end","call_id":"call_spawn_v131","sender_session_id":"parent-sess","new_session_id":"worker-sess-v131","new_agent_nickname":"Turing","new_agent_role":"worker","prompt":"Do work","status":"pending_init"}}"#,
+            r#"{"timestamp":"2026-05-18T10:00:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_spawn_v131","output":"{\"agent_id\":\"worker-sess-v131\",\"nickname\":\"Turing\"}"}}"#,
+            r#"{"timestamp":"2026-05-18T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562405.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].collab_spawns.len(), 1);
+        assert_eq!(turns[0].collab_spawns[0].new_thread_id, "worker-sess-v131");
+        assert_eq!(turns[0].collab_spawns[0].agent_nickname, "Turing");
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert_eq!(turns[0].tool_calls[0].kind, ToolKind::SpawnAgent);
     }
 }


### PR DESCRIPTION
## Summary

Codex v0.131.0 ([PR #22268](https://github.com/microsoft/codex/pull/22268)) renamed the `collab_agent_spawn_end` hook event field `new_thread_id` → `new_session_id` (and `sender_thread_id` → `sender_session_id`). This broke session correlation for spawned worker agents in sessions recorded with v0.131.0+.

## Changes

- **`src-tauri/src/parser/discover.rs`** — Session scanner now checks `new_thread_id` first, falls back to `new_session_id` when absent
- **`src-tauri/src/parser/turn.rs`** — Turn builder applies the same fallback when extracting the spawned agent ID

Both paths remain fully backward-compatible with pre-v0.131.0 sessions.

## Tests

Two new regression tests added:
- `discover_sessions_links_collab_spawn_end_event_v0131_new_session_id` — verifies the discover path handles `new_session_id`
- `links_spawn_agent_from_collab_spawn_end_with_new_session_id` — verifies the turn builder handles `new_session_id`

All 106 Rust tests pass. Clippy clean.

Fixes #63
