### PR TITLE
[#65]: Add v0.131.0 profile-v2 compat regression tests

### DIFF
--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -870,4 +870,70 @@ mod tests {
 
         assert_eq!(session.total_tokens, Some(1800));
     }
+
+    // Codex v0.131.0 (PRs #22594, #22647, #22724): profile-v2 layered config format.
+    //
+    // codex-trace reads only JSONL session files — never Codex TOML config files. The
+    // profile-v2 changes affect what appears in session_meta: a `profile` field may name
+    // the active profile; `instructions_file` is gone from config so instructions arrive
+    // via `base_instructions.text` or are absent entirely. The discover scanner must handle
+    // both cases without panicking.
+
+    #[test]
+    fn discover_sessions_v0131_profile_v2_session_discovered_correctly() {
+        // session_meta with profile-v2 `profile` field: discover scanner must not panic
+        // and must populate cli_version correctly from the payload.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/05/18");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-05-18T10-00-00-profilev2.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-18T10:00:00Z","type":"session_meta","payload":{"id":"v0131-disc-profile","timestamp":"2026-05-18T10:00:00Z","cwd":"/home/user","cli_version":"0.131.0","model_provider":"openai","profile":"work","base_instructions":{"text":"You are helpful."}}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562402.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0131-disc-profile")
+            .unwrap();
+        assert_eq!(session.cli_version.as_deref(), Some("0.131.0"));
+        assert_eq!(session.turn_count, 1);
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn discover_sessions_v0131_no_instructions_discovered_correctly() {
+        // sessions from v0.131.0 without instructions (instructions_file removed) must be
+        // discovered and indexed normally — the absent field has no effect on discovery.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/05/18");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-05-18T10-01-00-noinstr.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-18T10:01:00Z","type":"session_meta","payload":{"id":"v0131-disc-noinstr","timestamp":"2026-05-18T10:01:00Z","cwd":"/home/user","cli_version":"0.131.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-18T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562462.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0131-disc-noinstr")
+            .unwrap();
+        assert_eq!(session.cli_version.as_deref(), Some("0.131.0"));
+        assert_eq!(session.turn_count, 1);
+        assert!(!session.is_ongoing);
+    }
 }

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -356,4 +356,77 @@ mod tests {
         // The mcp_servers field is accessible via the payload but not required for parsing.
         assert!(e.payload.get("mcp_servers").is_some());
     }
+
+    // Codex v0.131.0 (PRs #22594, #22647, #22724): profile-v2 layered config format.
+    //
+    // PR #22594 introduced --profile-v2 as a new layered config file format.
+    // PR #22647 made Codex reject the legacy [profiles] TOML section when profile-v2 is active.
+    // PR #22724 removed the experimental `instructions_file` config key entirely.
+    //
+    // codex-trace does NOT read Codex CLI config files (TOML profiles). It reads only the
+    // JSONL session files at ~/.codex/sessions/. The profile-v2 changes affect what Codex
+    // writes into session_meta entries:
+    //   - A `profile` field may appear in session_meta indicating the active profile name.
+    //   - Instructions from the active profile arrive via `base_instructions.text` (already
+    //     read by parse_session_meta_new) or may be absent entirely when no profile is set.
+    //   - The `instructions_file` config key is gone — sessions from v0.131.0+ will not
+    //     have instructions sourced from that key (opt_str returns None gracefully).
+    //
+    // The loosely-typed RawEntry model ignores unknown fields, so profile-v2 metadata in
+    // session_meta does not cause parse failures or panics.
+
+    #[test]
+    fn v0131_session_meta_with_profile_v2_field_does_not_panic() {
+        // session_meta from a v0.131.0 session started with --profile-v2 active.
+        // The `profile` field names the active profile; codex-trace ignores it gracefully.
+        let line = r#"{"timestamp":"2026-05-18T10:00:00Z","type":"session_meta","payload":{"id":"v0131-profile-v2","timestamp":"2026-05-18T10:00:00Z","cwd":"/tmp","cli_version":"0.131.0","profile":"work","base_instructions":{"text":"You are a helpful assistant."}}}"#;
+        let e = RawEntry::parse(line).expect("session_meta with profile-v2 fields must parse");
+        assert_eq!(e.entry_type, "session_meta");
+        assert_eq!(e.payload["id"], "v0131-profile-v2");
+        assert_eq!(e.payload["cli_version"], "0.131.0");
+        assert_eq!(e.payload["profile"], "work");
+        assert_eq!(
+            e.payload["base_instructions"]["text"],
+            "You are a helpful assistant."
+        );
+    }
+
+    #[test]
+    fn v0131_session_meta_without_instructions_does_not_panic() {
+        // v0.131.0 removed `instructions_file` from the Codex config. Sessions started
+        // without a profile that provided instructions will have no `instructions` or
+        // `base_instructions` field — opt_str returns None, not an error.
+        let line = r#"{"timestamp":"2026-05-18T10:01:00Z","type":"session_meta","payload":{"id":"v0131-no-instructions","timestamp":"2026-05-18T10:01:00Z","cwd":"/home/user","cli_version":"0.131.0","model_provider":"openai"}}"#;
+        let e = RawEntry::parse(line).expect("session_meta without instructions must parse");
+        assert_eq!(e.entry_type, "session_meta");
+        assert_eq!(e.payload["id"], "v0131-no-instructions");
+        assert!(e.payload.get("instructions").is_none());
+        assert!(e.payload.get("base_instructions").is_none());
+    }
+
+    #[test]
+    fn v0131_all_standard_entry_types_parse_correctly() {
+        // Regression guard: all four standard JSONL entry types must parse under v0.131.0.
+        let lines = [
+            r#"{"timestamp":"2026-05-18T10:02:00Z","type":"session_meta","payload":{"id":"v0131-session","timestamp":"2026-05-18T10:02:00Z","cwd":"/tmp","cli_version":"0.131.0","profile":"default","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-05-18T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-18T10:02:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-05-18T10:02:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
+            r#"{"timestamp":"2026-05-18T10:02:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562524.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.131.0");
+        assert_eq!(meta.payload["profile"], "default");
+    }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -644,4 +644,97 @@ mod tests {
         assert_eq!(session.turns.len(), 1);
         assert!(!session.is_ongoing);
     }
+
+    // Codex v0.131.0 (PRs #22594, #22647, #22724): profile-v2 layered config format.
+    //
+    // codex-trace reads JSONL session files, not Codex CLI TOML config files. The profile-v2
+    // changes alter what Codex writes into session_meta: a `profile` field may appear naming
+    // the active profile, and instructions now come via `base_instructions.text` from the
+    // profile's system_prompt (the `instructions_file` config key is gone from Codex config).
+    // All cases below must parse without panics and produce correct field values.
+
+    #[test]
+    fn v0131_profile_v2_session_parses_correctly() {
+        // session_meta from v0.131.0 with --profile-v2 active: carries `profile` field and
+        // instructions sourced from the profile's system_prompt via base_instructions.text.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-18T10-00-00-profilev2.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-18T10:00:00Z","type":"session_meta","payload":{"id":"v0131-profile-v2","timestamp":"2026-05-18T10:00:00Z","cwd":"/home/user","cli_version":"0.131.0","model_provider":"openai","profile":"work","base_instructions":{"text":"You are a helpful assistant."}}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562402.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0131-profile-v2");
+        assert_eq!(session.cli_version.as_deref(), Some("0.131.0"));
+        // Instructions arrive from base_instructions.text (profile system_prompt).
+        assert_eq!(
+            session.instructions.as_deref(),
+            Some("You are a helpful assistant.")
+        );
+        assert_eq!(session.turns.len(), 1);
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn v0131_session_without_instructions_file_parses_correctly() {
+        // v0.131.0 removed `instructions_file` from the Codex config (PR #22724). Sessions
+        // started without a profile providing instructions will have no `instructions` or
+        // `base_instructions` in session_meta. The parser must return None, not panic.
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-05-18T10-01-00-noinstr.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-18T10:01:00Z","type":"session_meta","payload":{"id":"v0131-no-instructions","timestamp":"2026-05-18T10:01:00Z","cwd":"/home/user","cli_version":"0.131.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-18T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562462.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0131-no-instructions");
+        assert_eq!(session.cli_version.as_deref(), Some("0.131.0"));
+        // instructions_file is gone — no instructions in this session.
+        assert!(session.instructions.is_none());
+        assert_eq!(session.turns.len(), 1);
+    }
+
+    #[test]
+    fn v0131_legacy_profiles_section_absent_does_not_affect_session_parsing() {
+        // PR #22647: Codex now rejects legacy [profiles] TOML when profile-v2 is active.
+        // codex-trace reads only JSONL session files — it never touches Codex TOML config.
+        // This test confirms standard v0.131.0 session files parse correctly regardless of
+        // which config format the CLI was configured with.
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-05-18T10-02-00-v0131.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-18T10:02:00Z","type":"session_meta","payload":{"id":"v0131-standard","timestamp":"2026-05-18T10:02:00Z","cwd":"/workspace","cli_version":"0.131.0","model_provider":"openai","profile":"default"}}"#,
+                r#"{"timestamp":"2026-05-18T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-18T10:02:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+                r#"{"timestamp":"2026-05-18T10:02:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/workspace"}}"#,
+                r#"{"timestamp":"2026-05-18T10:02:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747562524.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0131-standard");
+        assert_eq!(session.cli_version.as_deref(), Some("0.131.0"));
+        assert_eq!(session.turns.len(), 1);
+        assert!(!session.is_ongoing);
+    }
 }


### PR DESCRIPTION
## Summary

Codex v0.131.0 (PRs #22594, #22647, #22724) introduced profile-v2 as a new layered config file format, rejected the legacy `[profiles]` TOML section when profile-v2 is active, and removed the `instructions_file` config key entirely.

**codex-trace does not read Codex CLI TOML config files.** It reads only JSONL session files at `~/.codex/sessions/`. The profile-v2 changes affect what Codex writes into `session_meta` entries in those files:

- A `profile` field may now appear in `session_meta` naming the active profile — the loosely-typed `RawEntry` model ignores unknown fields, so this does not cause parse failures.
- Instructions now arrive via `base_instructions.text` (already read by `parse_session_meta_new`) rather than `instructions_file` — this path was already handled; absent instructions gracefully return `None`.
- The `instructions_file` config key is gone from Codex config — `opt_str` returns `None` safely when the field is absent.

All three scenarios are already handled correctly by the existing parser. This PR adds regression tests to document and guard the v0.131.0 compat behavior.

## Changes

### Tests added (`src-tauri/src/parser/`)

**`entry.rs`**
- `v0131_session_meta_with_profile_v2_field_does_not_panic` — confirms `profile` field in `session_meta` is ignored gracefully
- `v0131_session_meta_without_instructions_does_not_panic` — confirms absent `instructions`/`base_instructions` returns `None`
- `v0131_all_standard_entry_types_parse_correctly` — regression guard for all four JSONL entry types under v0.131.0

**`session.rs`**
- `v0131_profile_v2_session_parses_correctly` — confirms `base_instructions.text` is read correctly from profile-sourced instructions
- `v0131_session_without_instructions_file_parses_correctly` — confirms sessions without any instructions field parse without panicking
- `v0131_legacy_profiles_section_absent_does_not_affect_session_parsing` — confirms v0.131.0 session files parse correctly regardless of which Codex config format was active

**`discover.rs`**
- `discover_sessions_v0131_profile_v2_session_discovered_correctly` — confirms discover scanner handles `profile` field without panicking
- `discover_sessions_v0131_no_instructions_discovered_correctly` — confirms discover scanner handles absent instructions

## Testing

All 120 Rust lib tests pass (112 pre-existing + 8 new):

```
test result: ok. 120 passed; 0 failed; 0 ignored
```

Clippy clean with `-D warnings`. Rust format clean.

Fixes #65
