### PR TITLE
[#64]: Remove dead formatted_output fallback, add Codex v0.132.0 regression tests

### DIFF
--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -329,15 +329,14 @@ impl ToolCallBuilder {
             .map(|s| s.to_string());
         let duration_secs = parse_duration(payload);
         // aggregated_output carries the actual command output; stdout is often empty.
-        let output = ["aggregated_output", "stdout", "formatted_output"]
-            .iter()
-            .find_map(|key| {
-                payload
-                    .get(*key)
-                    .and_then(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string())
-            });
+        // formatted_output was a legacy field removed in Codex v0.132.0 (PR #22706).
+        let output = ["aggregated_output", "stdout"].iter().find_map(|key| {
+            payload
+                .get(*key)
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+        });
         let status = str_field(payload, "status");
 
         self.finalized.push(ToolCall {
@@ -1052,6 +1051,45 @@ mod tests {
         let (server, tool) = parse_mcp_namespace("other__ns__tool", "fn_name");
         assert_eq!(server, None);
         assert_eq!(tool, None);
+    }
+
+    // Codex v0.132.0 (PR #22706): the legacy shell output formatting paths were removed.
+    // exec_command_end events no longer carry a `formatted_output` field; the output is
+    // exclusively in `aggregated_output`. The parser must read `aggregated_output` and
+    // must not require `formatted_output` to be present.
+    #[test]
+    fn exec_command_end_v0132_reads_aggregated_output_without_formatted_output() {
+        use super::super::super::parser::toolcall::ToolCallBuilder;
+        use serde_json::json;
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_1".to_string(),
+            "exec_command".to_string(),
+            r#"{"cmd":"echo hello","workdir":"/tmp"}"#,
+            None,
+            None,
+        );
+
+        // v0.132.0 exec_command_end: only aggregated_output, no formatted_output
+        let payload = json!({
+            "call_id": "call_1",
+            "aggregated_output": "hello\n",
+            "exit_code": 0,
+            "status": "completed",
+            "duration": {"secs": 0, "nanos": 120_000_000u64}
+        });
+        builder.finalize_exec("exec_command_end", &payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.output.as_deref(), Some("hello\n"));
+        assert_eq!(tool.exit_code, Some(0));
+        assert_eq!(tool.status, "completed");
+        assert!(
+            tool.duration_secs.is_some(),
+            "duration should be extracted from structured field"
+        );
     }
 
     #[test]

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -994,6 +994,64 @@ mod tests {
         assert_eq!(tool.status, "completed");
     }
 
+    // Codex v0.132.0 (PR #22706): the legacy shell output formatting paths were removed.
+    // function_call_output for exec_command now contains the raw command output only —
+    // no "Chunk ID:", "Wall time:", "Process exited with code N", "Output:" markers.
+    // The parser must preserve the full raw output and not attempt marker-based extraction.
+    #[test]
+    fn function_call_output_v0132_plain_text_no_legacy_markers() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-session","timestamp":"2026-05-20T10:00:00Z","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hello world\",\"workdir\":\"/tmp\"}","call_id":"call_exec"}}"#,
+            // v0.132.0: raw output only — no "Chunk ID", "Wall time", "Process exited", "Output:" markers
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_exec","output":"hello world\n"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::ExecCommand);
+        assert_eq!(tool.name, "exec_command");
+        // Raw output must be preserved in full — no marker stripping
+        assert_eq!(tool.output.as_deref(), Some("hello world\n"));
+        // No exit code extractable from plain text — None is correct
+        assert_eq!(tool.exit_code, None);
+        assert_eq!(tool.status, "completed");
+    }
+
+    // Codex v0.132.0 (PR #22706): exec_command_end events no longer include formatted_output.
+    // When both function_call_output (plain text, no markers) and exec_command_end (with
+    // aggregated_output) are present, the exec_command_end structured fields take precedence.
+    #[test]
+    fn exec_command_end_v0132_structured_output_and_exit_code() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-end-session","timestamp":"2026-05-20T10:00:00Z","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls /nonexistent\",\"workdir\":\"/tmp\"}","call_id":"call_ls"}}"#,
+            // v0.132.0: exec_command_end carries aggregated_output + structured exit_code + duration
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_ls","aggregated_output":"ls: /nonexistent: No such file or directory\n","exit_code":1,"status":"failed","duration":{"secs":0,"nanos":5000000}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::ExecCommand);
+        assert_eq!(
+            tool.output.as_deref(),
+            Some("ls: /nonexistent: No such file or directory\n")
+        );
+        assert_eq!(tool.exit_code, Some(1));
+        assert_eq!(tool.status, "failed");
+        assert!(tool.duration_secs.is_some());
+    }
+
     #[test]
     fn links_spawn_agent_from_collab_spawn_end_event() {
         let entries = entries(&[


### PR DESCRIPTION
## Summary

Codex v0.132.0 (PR #22706 "Remove legacy shell output formatting paths") removed the `formatted_output` field from `exec_command_end` events and the structured text markers (`Chunk ID:`, `Wall time:`, `Process exited with code N:`, `Output:`) from `function_call_output` content.

This PR removes the dead reference to `formatted_output` in the parser's output fallback chain and adds three regression tests that explicitly cover the v0.132.0 output shape.

## Changes

### `src-tauri/src/parser/toolcall.rs`

- **Remove `formatted_output` from `finalize_exec` fallback** (`["aggregated_output", "stdout", "formatted_output"]` → `["aggregated_output", "stdout"]`). The `formatted_output` field no longer exists in v0.132.0+ sessions; `aggregated_output` is the sole output field in `exec_command_end` events. Keeping the dead entry was misleading and could mask future issues.
- **Add test** `exec_command_end_v0132_reads_aggregated_output_without_formatted_output`: verifies that an `exec_command_end` payload with only `aggregated_output` (no `formatted_output`) correctly populates `output`, `exit_code`, and `duration_secs`.

### `src-tauri/src/parser/turn.rs`

- **Add test** `function_call_output_v0132_plain_text_no_legacy_markers`: verifies that a v0.132.0 `function_call_output` containing raw plain text (no `Chunk ID:`, `Wall time:`, `Process exited with code N:`, or `Output:` markers) preserves the full output string and resolves to `status="completed"` with `exit_code=None`.
- **Add test** `exec_command_end_v0132_structured_output_and_exit_code`: end-to-end turn parse of a v0.132.0 `exec_command_end` event carrying `aggregated_output`, structured `exit_code`, and `duration` fields — confirms the full pipeline (JSONL → `RawEntry` → `ToolCallBuilder::finalize_exec` → `ToolCall`) works without `formatted_output`.

## Verification

- All 107 Rust unit tests pass (`cargo test --lib`)
- Clippy clean (`cargo clippy -- -D warnings`)
- 128 frontend tests pass (`vitest run`)
- HTTP API smoke test passes (`POST /api/sessions` returns `200 []`)

Fixes #64
