### PR TITLE
feat(parser): add plugin_id support for Codex v0.133.0 MCP tool calls

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -55,6 +55,8 @@ export interface CodexToolCall {
   duration_secs: number | null;
   mcp_server: string | null;
   mcp_tool: string | null;
+  /** Codex v0.133.0+: identifies which plugin the MCP tool belongs to. Null for pre-v0.133.0 sessions. */
+  plugin_id: string | null;
   patch_success: boolean | null;
   patch_changes: Record<string, { type: string; content?: string; unified_diff?: string }> | null;
   web_query: string | null;

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -32,6 +32,9 @@ pub struct ToolCall {
     pub duration_secs: Option<f64>,
     pub mcp_server: Option<String>,
     pub mcp_tool: Option<String>,
+    /// Codex v0.133.0 (PRs #23353, #23737): plugin_id identifies which plugin
+    /// an MCP tool belongs to. Absent for pre-v0.133.0 sessions and non-MCP calls.
+    pub plugin_id: Option<String>,
     pub patch_success: Option<bool>,
     pub patch_changes: Option<Value>,
     pub web_query: Option<String>,
@@ -51,6 +54,8 @@ pub struct PendingCall {
     pub namespace: Option<String>,
     /// v0.130.0+: direct MCP server name from tool_id.server (bypasses namespace parsing).
     pub mcp_server: Option<String>,
+    /// v0.133.0+: plugin_id from tool_id.plugin_id or mcp_tool_call.plugin_id.
+    pub plugin_id: Option<String>,
 }
 
 /// Builder that collects function_call / custom_tool_call entries and finalizes
@@ -80,6 +85,7 @@ impl ToolCallBuilder {
         arguments_str: &str,
         namespace: Option<String>,
         mcp_server_direct: Option<String>,
+        plugin_id: Option<String>,
     ) {
         let arguments = serde_json::from_str(arguments_str).unwrap_or(Value::Null);
         self.pending.insert(
@@ -90,6 +96,7 @@ impl ToolCallBuilder {
                 input_text: None,
                 namespace,
                 mcp_server: mcp_server_direct,
+                plugin_id,
             },
         );
     }
@@ -104,6 +111,7 @@ impl ToolCallBuilder {
                 input_text: input,
                 namespace: None,
                 mcp_server: None,
+                plugin_id: None,
             },
         );
     }
@@ -129,6 +137,7 @@ impl ToolCallBuilder {
                 duration_secs: None,
                 mcp_server: None,
                 mcp_tool: None,
+                plugin_id: None,
                 patch_success: exit_code.map(|c| c == 0),
                 patch_changes: None,
                 web_query: None,
@@ -219,6 +228,7 @@ impl ToolCallBuilder {
                     duration_secs: None,
                     mcp_server: None,
                     mcp_tool: None,
+                    plugin_id: None,
                     patch_success: None,
                     patch_changes: None,
                     web_query: None,
@@ -248,6 +258,11 @@ impl ToolCallBuilder {
                     _ => (ToolKind::Unknown, None, None),
                 }
             };
+            let plugin_id = if kind == ToolKind::McpTool {
+                pending.plugin_id
+            } else {
+                None
+            };
             self.finalized.push(ToolCall {
                 call_id: call_id.to_string(),
                 kind,
@@ -261,6 +276,7 @@ impl ToolCallBuilder {
                 duration_secs: None,
                 mcp_server,
                 mcp_tool,
+                plugin_id,
                 patch_success: None,
                 patch_changes: None,
                 web_query: None,
@@ -314,6 +330,7 @@ impl ToolCallBuilder {
                 input_text: None,
                 namespace: None,
                 mcp_server: None,
+                plugin_id: None,
             });
 
         let command: Option<Vec<String>> = payload
@@ -353,6 +370,7 @@ impl ToolCallBuilder {
             duration_secs,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -375,6 +393,7 @@ impl ToolCallBuilder {
                 input_text: None,
                 namespace: None,
                 mcp_server: None,
+                plugin_id: None,
             });
 
         // Extract server + tool from invocation field, then namespace, then name.
@@ -398,6 +417,7 @@ impl ToolCallBuilder {
         // Extract output text from result.Ok.content[].text
         let output = extract_mcp_output(payload);
         let duration_secs = parse_duration(payload);
+        let plugin_id = pending.plugin_id;
 
         self.finalized.push(ToolCall {
             call_id,
@@ -412,6 +432,7 @@ impl ToolCallBuilder {
             duration_secs,
             mcp_server,
             mcp_tool,
+            plugin_id,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -479,6 +500,7 @@ impl ToolCallBuilder {
                 input_text: None,
                 namespace: None,
                 mcp_server: None,
+                plugin_id: None,
             });
 
         self.finalized.push(ToolCall {
@@ -494,6 +516,7 @@ impl ToolCallBuilder {
             duration_secs: None,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success,
             patch_changes,
             web_query: None,
@@ -522,6 +545,7 @@ impl ToolCallBuilder {
             duration_secs: None,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -550,6 +574,7 @@ impl ToolCallBuilder {
             duration_secs: None,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -578,6 +603,7 @@ impl ToolCallBuilder {
             duration_secs: None,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -615,6 +641,7 @@ impl ToolCallBuilder {
             duration_secs: None,
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: query,
@@ -637,6 +664,7 @@ impl ToolCallBuilder {
                 input_text: None,
                 namespace: None,
                 mcp_server: None,
+                plugin_id: None,
             });
         let output = ["output", "aggregated_output", "stdout"]
             .iter()
@@ -660,6 +688,7 @@ impl ToolCallBuilder {
             duration_secs: parse_duration(payload),
             mcp_server: None,
             mcp_tool: None,
+            plugin_id: None,
             patch_success: None,
             patch_changes: None,
             web_query: None,
@@ -687,6 +716,7 @@ impl ToolCallBuilder {
                 duration_secs: None,
                 mcp_server: None,
                 mcp_tool: None,
+                plugin_id: None,
                 patch_success: None,
                 patch_changes: None,
                 web_query: None,
@@ -740,6 +770,7 @@ fn exec_tool_call_from_pending(
         duration_secs: parsed_output.duration_secs,
         mcp_server: None,
         mcp_tool: None,
+        plugin_id: None,
         patch_success: None,
         patch_changes: None,
         web_query: None,

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -579,9 +579,10 @@ fn handle_response_item(
             // v0.130.0+ (PR #21454): string-keyed MCP tool maps removed; function_call
             // entries now carry tool_id: { server, tool } instead of a flat namespace string.
             // Store the server directly to avoid parse_mcp_namespace misinterpreting it.
+            // v0.133.0+ (PRs #23353, #23737): tool_id also carries plugin_id.
+            let tool_id = payload.get("tool_id");
             let mcp_server_direct = if namespace.is_none() {
-                payload
-                    .get("tool_id")
+                tool_id
                     .and_then(|tid| tid.get("server"))
                     .and_then(|s| s.as_str())
                     .filter(|s| !s.is_empty())
@@ -589,7 +590,19 @@ fn handle_response_item(
             } else {
                 None
             };
-            builder.add_function_call(call_id, name, arguments_str, namespace, mcp_server_direct);
+            let plugin_id = tool_id
+                .and_then(|tid| tid.get("plugin_id"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            builder.add_function_call(
+                call_id,
+                name,
+                arguments_str,
+                namespace,
+                mcp_server_direct,
+                plugin_id,
+            );
         }
 
         "function_call_output" => {
@@ -682,7 +695,14 @@ fn handle_response_item(
                 Some(v) => serde_json::to_string(v).unwrap_or_else(|_| "{}".to_string()),
                 None => "{}".to_string(),
             };
-            builder.add_function_call(call_id, name, &arguments_str, namespace, None);
+            // v0.133.0+ (PRs #23353, #23737): plugin_id field identifies which plugin
+            // the MCP tool belongs to. Absent for older sessions.
+            let plugin_id = payload
+                .get("plugin_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            builder.add_function_call(call_id, name, &arguments_str, namespace, None, plugin_id);
         }
 
         "mcp_tool_call_output" => {
@@ -1636,5 +1656,66 @@ mod tests {
         assert_eq!(user_tool.kind, ToolKind::McpTool);
         assert_eq!(user_tool.mcp_server.as_deref(), Some("github"));
         assert_eq!(user_tool.mcp_tool.as_deref(), Some("get_pr_info"));
+    }
+
+    // Codex v0.133.0 (PRs #23353, #23737): plugin_id added to MCP tool call items.
+
+    #[test]
+    fn mcp_tool_call_with_plugin_id_is_captured() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-21T10:00:00Z","type":"session_meta","payload":{"id":"s-pid1","timestamp":"2026-05-21T10:00:00Z","cli_version":"0.133.0"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:02Z","type":"response_item","payload":{"type":"mcp_tool_call","call_id":"mcp-pid1","server":"github","tool":"get_pr_info","plugin_id":"plugin-abc","arguments":{"pr_number":1}}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:03Z","type":"response_item","payload":{"type":"mcp_tool_call_output","call_id":"mcp-pid1","output":"PR info"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747821604.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::McpTool);
+        assert_eq!(tool.mcp_server.as_deref(), Some("github"));
+        assert_eq!(tool.plugin_id.as_deref(), Some("plugin-abc"));
+    }
+
+    #[test]
+    fn function_call_with_tool_id_plugin_id_is_captured() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-21T10:00:00Z","type":"session_meta","payload":{"id":"s-pid2","timestamp":"2026-05-21T10:00:00Z","cli_version":"0.133.0"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"get_pr_info","call_id":"fc-pid1","arguments":"{}","tool_id":{"server":"github","tool":"get_pr_info","plugin_id":"plugin-xyz"}}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"fc-pid1","output":"result"}}"#,
+            r#"{"timestamp":"2026-05-21T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747821604.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::McpTool);
+        assert_eq!(tool.mcp_server.as_deref(), Some("github"));
+        assert_eq!(tool.plugin_id.as_deref(), Some("plugin-xyz"));
+    }
+
+    #[test]
+    fn mcp_tool_call_without_plugin_id_has_none() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-07T10:00:00Z","type":"session_meta","payload":{"id":"s-nopid","timestamp":"2026-05-07T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-05-07T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-07T10:00:02Z","type":"response_item","payload":{"type":"mcp_tool_call","call_id":"mcp-nopid","server":"slack","tool":"list_channels","arguments":{}}}"#,
+            r#"{"timestamp":"2026-05-07T10:00:03Z","type":"response_item","payload":{"type":"mcp_tool_call_output","call_id":"mcp-nopid","output":"[]"}}"#,
+            r#"{"timestamp":"2026-05-07T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1747821604.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::McpTool);
+        assert!(
+            tool.plugin_id.is_none(),
+            "pre-v0.133.0 MCP call must have no plugin_id"
+        );
     }
 }

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -17,6 +17,7 @@ function makeTool(overrides: Partial<CodexToolCall> = {}): CodexToolCall {
     duration_secs: 0.5,
     mcp_server: null,
     mcp_tool: null,
+    plugin_id: null,
     patch_success: null,
     patch_changes: null,
     web_query: null,

--- a/src/components/TurnList.test.tsx
+++ b/src/components/TurnList.test.tsx
@@ -33,6 +33,7 @@ const EXEC_TOOL: CodexToolCall = {
   duration_secs: 0.1,
   mcp_server: null,
   mcp_tool: null,
+  plugin_id: null,
   patch_success: null,
   patch_changes: null,
   web_query: null,

--- a/src/components/WorkerPanel.test.tsx
+++ b/src/components/WorkerPanel.test.tsx
@@ -20,6 +20,7 @@ function makeTool(overrides: Partial<CodexToolCall> = {}): CodexToolCall {
     duration_secs: 0.5,
     mcp_server: null,
     mcp_tool: null,
+    plugin_id: null,
     patch_success: null,
     patch_changes: null,
     web_query: null,


### PR DESCRIPTION
## Summary

Codex v0.133.0 (PRs #23353, #23737) added a `plugin_id` field to MCP tool call items and their metadata. This PR adds support for that field so sessions produced by Codex v0.133.0+ are parsed correctly and the plugin identity is exposed via the HTTP API.

## Changes

**`src-tauri/src/parser/toolcall.rs`**
- Added `plugin_id: Option<String>` to `ToolCall` struct (serialized to JSON for the API)
- Added `plugin_id: Option<String>` to `PendingCall` struct
- Updated `add_function_call` signature to accept `plugin_id`
- Propagated `plugin_id` through all `ToolCallBuilder` finalization paths; non-MCP calls receive `None`

**`src-tauri/src/parser/turn.rs`**
- `function_call` handler: extracts `plugin_id` from `tool_id.plugin_id` (the v0.130.0+ `tool_id` object path)
- `mcp_tool_call` handler: extracts `plugin_id` from the payload directly (the v0.129.0+ first-class MCP item path)
- Added 3 new tests: `mcp_tool_call_with_plugin_id_is_captured`, `function_call_with_tool_id_plugin_id_is_captured`, `mcp_tool_call_without_plugin_id_has_none`

**`shared/types.ts`**
- Added `plugin_id: string | null` to `CodexToolCall` interface

**`src/components/*.test.tsx`**
- Updated three test fixtures to include the required `plugin_id: null` field

## Compatibility

Pre-v0.133.0 sessions are unaffected — `plugin_id` is `None`/`null` when the field is absent. Both the `mcp_tool_call` path (v0.129.0+) and the `function_call`/`tool_id` path (v0.130.0+) are covered.

## Test Results

- 107 Rust unit tests pass (`cargo test --lib`)
- 128 frontend tests pass (`npx vitest run`)
- HTTP API smoke test: `POST /api/sessions` returns `[]` ✓

Fixes #68
