### PR TITLE
fix(install): build a proper .app bundle on macOS (fixes blank white window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ Use this option if you want to build Codex Trace locally on macOS, Linux, or Win
 ```bash
 git clone https://github.com/PixelPaw-Labs/codex-trace.git
 cd codex-trace
-./script/install.sh       # builds frontend + installs Rust binary
+./script/install.sh       # macOS → Codex Trace.app in /Applications; Linux → cargo binary
 
-codex-trace              # desktop app (default)
-codex-trace --web        # web mode (opens browser)
+# Launch the desktop app:
+#   macOS:  open -a "Codex Trace"   (or from Launchpad/Applications)
+#   Linux:  codex-trace
+codex-trace --web         # web mode (opens browser)
 ```
 
 ### Run from source without installing

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,25 +1,62 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install codex-trace binary.
-# Builds the frontend, then installs the Rust binary to ~/.cargo/bin,
-# and links the CLI as a global npm command.
+# Install codex-trace.
+#
+# Platform-specific, because the right artifact differs:
+#   - macOS: build a proper `.app` bundle via `tauri build` and install it to
+#     /Applications. `cargo install` only produces a bare Mach-O binary with no
+#     Info.plist / GUI activation policy, which shows a blank white window on
+#     macOS. The backend and frontend are fine; only the bundling is wrong.
+#   - Linux/other: a bare binary from `cargo install` works fine (there is no
+#     `.app` concept), so keep the original flow.
 
 cd "$(dirname "$0")/.."
 
 echo "==> Installing npm dependencies..."
 npm install
 
-echo "==> Building frontend..."
-npm run build
+OS="$(uname -s)"
 
-echo "==> Installing binary via cargo..."
-cargo install --path src-tauri
+if [ "$OS" = "Darwin" ]; then
+  # `tauri build` runs the frontend build itself (beforeBuildCommand).
+  echo "==> Building macOS .app bundle (tauri build)..."
+  npx tauri build --bundles app
 
-echo "==> Linking codex-trace CLI..."
-npm link
+  APP_SRC="src-tauri/target/release/bundle/macos/Codex Trace.app"
+  APP_DEST="/Applications/Codex Trace.app"
 
-echo ""
-echo "Installed! Run:"
-echo "  codex-trace          # desktop app (default)"
-echo "  codex-trace --web    # web mode (opens browser)"
+  echo "==> Installing to ${APP_DEST}..."
+  rm -rf "$APP_DEST"
+  cp -R "$APP_SRC" "$APP_DEST"
+
+  # A stale `cargo install` binary in ~/.cargo/bin shadows everything else on
+  # PATH and reintroduces the white-screen bug, so remove it.
+  if [ -f "$HOME/.cargo/bin/codex-trace" ]; then
+    echo "==> Removing stale cargo-installed binary (~/.cargo/bin/codex-trace)..."
+    cargo uninstall codex-trace >/dev/null 2>&1 || rm -f "$HOME/.cargo/bin/codex-trace"
+  fi
+
+  # Keep the `codex-trace` CLI (dev/web modes) available on PATH.
+  echo "==> Linking codex-trace CLI..."
+  npm link
+
+  echo ""
+  echo "Installed! Launch the desktop app from Launchpad/Applications, or:"
+  echo "  open -a \"Codex Trace\"   # desktop app"
+  echo "  codex-trace --web        # web mode (opens browser)"
+else
+  echo "==> Building frontend..."
+  npm run build
+
+  echo "==> Installing binary via cargo..."
+  cargo install --path src-tauri
+
+  echo "==> Linking codex-trace CLI..."
+  npm link
+
+  echo ""
+  echo "Installed! Run:"
+  echo "  codex-trace          # desktop app (default)"
+  echo "  codex-trace --web    # web mode (opens browser)"
+fi


### PR DESCRIPTION
## Problem

On macOS, installing via `./script/install.sh` and launching `codex-trace` shows a **blank white window**. The HTTP backend starts fine (`HTTP API: listening on http://127.0.0.1:11424`), but the Tauri webview never renders any content.

## Root cause

`install.sh` installs the binary with `cargo install --path src-tauri`. On macOS that produces a **bare Mach-O binary** in `~/.cargo/bin` — there is no `.app` bundle, no `Info.plist`, and no GUI activation policy. Tauri's macOS WebView needs a proper `.app` bundle to render reliably; the bare binary comes up blank.

The frontend and backend themselves are fine — the same `dist` renders correctly when served over HTTP, which is how this was isolated to the bundling step.

## Fix

Make the installer platform-aware:

- **macOS**: build a real bundle with `tauri build --bundles app`, install `Codex Trace.app` into `/Applications`, and remove any stale `cargo install` binary that would shadow it on `PATH` (and reintroduce the bug).
- **Linux / other**: unchanged — a bare `cargo install` binary is the correct artifact there (no `.app` concept).

`README` is updated to match.

## Testing

- `bash -n script/install.sh` passes. (The repo has no shell test framework; shell changes are validated by syntax check.)
- Verified end-to-end on Apple Silicon macOS: `tauri build --bundles app` → `Codex Trace.app` in `/Applications` launches and renders correctly — no more blank window.
