### PR TITLE
feat(detail): show tool calls inline in chronological order

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -19,6 +19,9 @@ export interface AgentMessage {
   phase: "commentary" | "final_answer" | null;
   timestamp: string;
   is_reasoning: boolean;
+  /** Position in the raw entry stream. `CodexTurn.tool_call_orders` uses the same scale, so
+   * the UI can interleave messages and tool calls chronologically. Absent for old cached data. */
+  order?: number;
 }
 
 /** Codex v0.135.0 (PR #24368): compaction metadata from turn headers. */
@@ -85,6 +88,9 @@ export interface CodexTurn {
   user_message: string | null;
   agent_messages: AgentMessage[];
   tool_calls: CodexToolCall[];
+  /** Display-order index for each tool call, parallel to `tool_calls` (same length/order).
+   * Same scale as `AgentMessage.order`. Absent for old cached data. */
+  tool_call_orders?: number[];
   final_answer: string | null;
   total_tokens: TokenInfo | null;
   model: string | null;

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -22,6 +22,12 @@ pub struct AgentMsg {
     pub phase: Option<String>,
     pub timestamp: String,
     pub is_reasoning: bool,
+    /// Position of this message in the raw entry stream. Tool calls carry a parallel index
+    /// (see `CodexTurn::tool_call_orders`) drawn from the same counter, so the frontend can
+    /// interleave messages and tool calls in true chronological order instead of rendering
+    /// them in separate blocks.
+    #[serde(default)]
+    pub order: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,6 +88,12 @@ pub struct CodexTurn {
     pub text_elements: Vec<TextElement>,
     pub agent_messages: Vec<AgentMsg>,
     pub tool_calls: Vec<ToolCall>,
+    /// Display-order index for each tool call, parallel to `tool_calls` (same length, same
+    /// order). The value is the position of the call's first appearance in the raw entry
+    /// stream, matching `AgentMsg::order`, so the frontend can interleave tool calls with
+    /// agent messages instead of dumping all tool calls at the end of the turn.
+    #[serde(default)]
+    pub tool_call_orders: Vec<usize>,
     pub final_answer: Option<String>,
     pub total_tokens: Option<TokenInfo>,
     pub model: Option<String>,
@@ -118,6 +130,7 @@ impl CodexTurn {
             text_elements: Vec::new(),
             agent_messages: Vec::new(),
             tool_calls: Vec::new(),
+            tool_call_orders: Vec::new(),
             final_answer: None,
             total_tokens: None,
             model: None,
@@ -150,8 +163,15 @@ pub fn build_turns(entries: &[RawEntry]) -> Vec<CodexTurn> {
     });
 
     let mut synthetic_turn_counter = 0u32;
+    // Position of each tool call's first appearance in the raw stream, keyed by call_id.
+    // Gives tool calls the same kind of order index as agent messages so the two can be
+    // interleaved chronologically in the UI.
+    let mut call_order: HashMap<String, usize> = HashMap::new();
 
-    for entry in entries {
+    for (index, entry) in entries.iter().enumerate() {
+        if let Some(call_id) = call_id_of(entry) {
+            call_order.entry(call_id).or_insert(index);
+        }
         match entry.entry_type.as_str() {
             "event_msg" => {
                 handle_event_msg(
@@ -161,6 +181,7 @@ pub fn build_turns(entries: &[RawEntry]) -> Vec<CodexTurn> {
                     &mut tool_builders,
                     has_task_started,
                     &mut synthetic_turn_counter,
+                    index,
                 );
             }
             "response_item"
@@ -188,6 +209,12 @@ pub fn build_turns(entries: &[RawEntry]) -> Vec<CodexTurn> {
     for (turn_id, mut builder) in tool_builders {
         builder.drain_pending();
         if let Some(turn) = turns.get_mut(&turn_id) {
+            // Record each call's stream position, parallel to tool_calls. Calls with no
+            // recorded position (should not happen for well-formed sessions) sort last.
+            for tc in &builder.finalized {
+                let order = call_order.get(&tc.call_id).copied().unwrap_or(usize::MAX);
+                turn.tool_call_orders.push(order);
+            }
             turn.tool_calls.extend(builder.finalized);
         }
     }
@@ -197,6 +224,22 @@ pub fn build_turns(entries: &[RawEntry]) -> Vec<CodexTurn> {
     result
 }
 
+/// Extract a tool call's `call_id` from a raw entry, checking both the parsed payload and the
+/// raw line (different entry shapes carry it in different places). Returns None for entries not
+/// associated with a tool call.
+fn call_id_of(entry: &RawEntry) -> Option<String> {
+    for v in [&entry.payload, &entry.raw] {
+        if let Some(cid) = v
+            .get("call_id")
+            .and_then(|c| c.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            return Some(cid.to_string());
+        }
+    }
+    None
+}
+
 fn handle_event_msg(
     entry: &RawEntry,
     turns: &mut indexmap::IndexMap<String, CodexTurn>,
@@ -204,6 +247,7 @@ fn handle_event_msg(
     tool_builders: &mut HashMap<String, ToolCallBuilder>,
     has_task_started: bool,
     synthetic_counter: &mut u32,
+    index: usize,
 ) {
     let payload = &entry.payload;
     let msg_type = match payload.get("type").and_then(|t| t.as_str()) {
@@ -311,6 +355,7 @@ fn handle_event_msg(
                             phase,
                             timestamp: ts.to_string(),
                             is_reasoning: false,
+                            order: index,
                         });
                     }
                 }
@@ -331,6 +376,7 @@ fn handle_event_msg(
                             phase: None,
                             timestamp: ts.to_string(),
                             is_reasoning: true,
+                            order: index,
                         });
                     }
                 }
@@ -1009,6 +1055,40 @@ mod tests {
             .iter()
             .filter_map(|line| RawEntry::parse(line))
             .collect()
+    }
+
+    #[test]
+    fn orders_messages_and_tool_calls_by_stream_position() {
+        // A tool call that happens between two agent messages must sort between them, so the
+        // UI can render it inline instead of dumping all tool calls at the end of the turn.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-04-27T04:53:00Z","type":"session_meta","payload":{"id":"s","timestamp":"2026-04-27T04:53:00Z"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:02Z","type":"event_msg","payload":{"type":"agent_message","message":"FIRST"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:03Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hi\",\"workdir\":\"/tmp\"}","call_id":"call_exec"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:04Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_exec","output":"Output:\nhi\nProcess exited with code 0\n"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:05Z","type":"event_msg","payload":{"type":"agent_message","message":"SECOND"}}"#,
+            r#"{"timestamp":"2026-04-27T04:53:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1777279986.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.agent_messages.len(), 2);
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_call_orders.len(), turn.tool_calls.len());
+
+        let first_msg_order = turn.agent_messages[0].order;
+        let second_msg_order = turn.agent_messages[1].order;
+        let tool_order = turn.tool_call_orders[0];
+        assert!(
+            first_msg_order < tool_order,
+            "tool call ({tool_order}) should sort after the first message ({first_msg_order})"
+        );
+        assert!(
+            tool_order < second_msg_order,
+            "tool call ({tool_order}) should sort before the second message ({second_msg_order})"
+        );
     }
 
     #[test]

--- a/src/components/TurnDetail.test.tsx
+++ b/src/components/TurnDetail.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentMessage, CodexTurn, TokenInfo } from "../../shared/types";
+import type { AgentMessage, CodexToolCall, CodexTurn, TokenInfo } from "../../shared/types";
 import { TurnDetail } from "./TurnDetail";
 
 const TOKEN_INFO: TokenInfo = {
@@ -46,6 +46,32 @@ function makeTurn(overrides: Partial<CodexTurn> = {}): CodexTurn {
   };
 }
 
+function makeTool(overrides: Partial<CodexToolCall> = {}): CodexToolCall {
+  return {
+    call_id: "call-1",
+    kind: "exec_command",
+    name: "shell",
+    arguments: {},
+    input_text: null,
+    output: "out",
+    exit_code: 0,
+    command: ["echo", "hi"],
+    cwd: "/tmp",
+    duration_secs: 0.1,
+    mcp_server: null,
+    mcp_tool: null,
+    plugin_id: null,
+    patch_success: null,
+    patch_changes: null,
+    web_query: null,
+    web_url: null,
+    image_prompt: null,
+    worker_session: null,
+    status: "completed",
+    ...overrides,
+  };
+}
+
 function renderTurnDetail(turn: CodexTurn) {
   render(<TurnDetail turn={turn} expanded={new Set()} onToggle={vi.fn()} onBack={vi.fn()} />);
 }
@@ -71,5 +97,46 @@ describe("TurnDetail", () => {
 
     expect(screen.queryByText(/ctx .* left/)).not.toBeInTheDocument();
     expect(screen.getByText("40.0k tok · 1m")).toBeInTheDocument();
+  });
+
+  it("interleaves tool calls with commentary by stream order", () => {
+    const first: AgentMessage = {
+      text: "FIRST_MESSAGE",
+      phase: "commentary",
+      timestamp: "2026-04-26T10:00:00Z",
+      is_reasoning: false,
+      order: 0,
+    };
+    const second: AgentMessage = {
+      text: "SECOND_MESSAGE",
+      phase: "commentary",
+      timestamp: "2026-04-26T10:00:02Z",
+      is_reasoning: false,
+      order: 2,
+    };
+    // Tool call's stream order (1) sits between the two messages (0 and 2), so it must render
+    // between them — not after both.
+    const tool = makeTool({ call_id: "c1", command: ["TOOL_MARKER_CMD"] });
+    const { container } = render(
+      <TurnDetail
+        turn={makeTurn({
+          agent_messages: [first, second],
+          tool_calls: [tool],
+          tool_call_orders: [1],
+          final_answer: null,
+        })}
+        expanded={new Set([0])}
+        onToggle={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    const text = container.textContent ?? "";
+    const iFirst = text.indexOf("FIRST_MESSAGE");
+    const iTool = text.indexOf("TOOL_MARKER_CMD");
+    const iSecond = text.indexOf("SECOND_MESSAGE");
+    expect(iFirst).toBeGreaterThanOrEqual(0);
+    expect(iTool).toBeGreaterThan(iFirst);
+    expect(iSecond).toBeGreaterThan(iTool);
   });
 });

--- a/src/components/TurnDetail.tsx
+++ b/src/components/TurnDetail.tsx
@@ -1,4 +1,4 @@
-import type { CodexToolCall, CodexTurn } from "../../shared/types";
+import type { AgentMessage, CodexToolCall, CodexTurn } from "../../shared/types";
 import { ToolCallItem } from "./ToolCallItem";
 import { OngoingDots } from "./OngoingDots";
 import { BackIcon, CodexIcon } from "./Icons";
@@ -29,6 +29,23 @@ export function TurnDetail({
   );
   const reasoning = turn.agent_messages.filter((m) => m.is_reasoning);
   const finalAnswer = turn.agent_messages.find((m) => m.phase === "final_answer");
+
+  // Interleave commentary messages with tool calls by their stream order, so each tool call
+  // shows up inline where it actually happened instead of being dumped at the end of the turn.
+  // When order data is missing (old cached sessions), messages keep order 0 and tools sort last,
+  // which reproduces the previous "messages first, tools after" layout.
+  type TimelineItem =
+    | { order: number; kind: "msg"; msg: AgentMessage }
+    | { order: number; kind: "tool"; tool: CodexToolCall; index: number };
+  const timeline: TimelineItem[] = [];
+  commentary.forEach((msg) => {
+    timeline.push({ order: msg.order ?? 0, kind: "msg", msg });
+  });
+  turn.tool_calls.forEach((tool, index) => {
+    const order = turn.tool_call_orders?.[index] ?? Number.MAX_SAFE_INTEGER;
+    timeline.push({ order, kind: "tool", tool, index });
+  });
+  timeline.sort((a, b) => a.order - b.order);
   const model = turn.model ? shortModel(turn.model) : "";
   const modelColor = turn.model ? getModelColor(turn.model) : undefined;
 
@@ -106,23 +123,33 @@ export function TurnDetail({
             </div>
           )}
 
-          {commentary.length > 0 && (
-            <div className="turn-detail__section turn-detail__section--commentary">
-              <div className="turn-detail__section-label">Commentary</div>
-              {commentary.map((msg, i) => (
-                <div key={msg.timestamp ?? i} className="turn-detail__msg">
-                  {msg.timestamp && (
-                    <div className="turn-detail__msg-header">
-                      <span className="turn-detail__msg-time">
-                        {formatExactTime(msg.timestamp)}
-                      </span>
+          {timeline.length > 0 && (
+            <div className="turn-detail__section turn-detail__section--activity">
+              {timeline.map((item, i) =>
+                item.kind === "msg" ? (
+                  <div key={`m-${item.msg.timestamp || i}`} className="turn-detail__msg">
+                    {item.msg.timestamp && (
+                      <div className="turn-detail__msg-header">
+                        <span className="turn-detail__msg-time">
+                          {formatExactTime(item.msg.timestamp)}
+                        </span>
+                      </div>
+                    )}
+                    <div className="turn-detail__markdown">
+                      <MarkdownRenderer content={item.msg.text} />
                     </div>
-                  )}
-                  <div className="turn-detail__markdown">
-                    <MarkdownRenderer content={msg.text} />
                   </div>
-                </div>
-              ))}
+                ) : (
+                  <ToolCallItem
+                    key={`t-${item.tool.call_id || item.index}`}
+                    tool={item.tool}
+                    expanded={expanded.has(item.index)}
+                    onToggle={() => onToggle(item.index)}
+                    isWorkerOpen={item.tool.call_id === openWorkerCallId}
+                    onOpenWorker={onOpenWorkerPanel}
+                  />
+                ),
+              )}
             </div>
           )}
 
@@ -141,24 +168,6 @@ export function TurnDetail({
                   <MarkdownRenderer content={finalAnswer.text} />
                 </div>
               </div>
-            </div>
-          )}
-
-          {turn.tool_calls.length > 0 && (
-            <div className="turn-detail__section turn-detail__section--tools">
-              <div className="turn-detail__section-label">
-                Tool calls ({turn.tool_calls.length})
-              </div>
-              {turn.tool_calls.map((tool, i) => (
-                <ToolCallItem
-                  key={tool.call_id || i}
-                  tool={tool}
-                  expanded={expanded.has(i)}
-                  onToggle={() => onToggle(i)}
-                  isWorkerOpen={tool.call_id === openWorkerCallId}
-                  onOpenWorker={onOpenWorkerPanel}
-                />
-              ))}
             </div>
           )}
 


### PR DESCRIPTION
## Problem

In the turn detail view, every tool call is dumped into one big "Tool calls (N)" block at the **bottom** of the turn, after all of the agent's text. Because Codex interleaves prose and tool calls as it works, this loses the chronology: to understand a turn you scroll past all the commentary to find the tools, then scroll back to figure out which message each tool belonged to.

## Cause

`build_turns` pushes agent messages in stream order (each carries a timestamp / order), but tool calls go through a `ToolCallBuilder` and are `extend`-ed onto the turn **all at once at the end**. `ToolCall` itself carries no position, so the frontend has no key to interleave on — it renders all messages first, then all tools.

## Fix (kept deliberately minimal)

- **Backend (`turn.rs`)**: while walking the raw entries, record each tool call's first-appearance index by `call_id` and store it as a **parallel `tool_call_orders` array on the turn** (same scale as `AgentMsg.order`). **`toolcall.rs` is untouched** — none of the ~13 `ToolCall` construction sites change.
- **Types**: two optional fields (`AgentMessage.order?`, `CodexTurn.tool_call_orders?`). Old cached data falls back to the previous "messages first, tools last" layout.
- **Frontend (`TurnDetail.tsx`)**: merge commentary and tool calls by `order` into a single timeline. Reasoning and final-answer blocks are unchanged.

## Result

Each tool call now renders inline, right after the message that triggered it — the detail view reads like the real session log. `update_plan` / `spawn_agent` / `wait_agent` / `close_agent` and all exec/mcp/patch calls land in their true positions.

## Testing

- New backend test: a tool call between two agent messages sorts between them.
- New frontend test: the tool renders between two commentary messages.
- Full suite green: **167 Rust + 129 frontend**. `tsc`, `oxlint`, `oxfmt`, `cargo fmt`, `clippy` all clean.
