### PR TITLE
[#102]: recognise assign_task and followup_task as FollowupTask

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -50,6 +50,8 @@ export type ToolKind =
   | "spawn_agent"
   | "wait_agent"
   | "close_agent"
+  /** multi-agent v2: assign_task (Codex < v0.136.0) or followup_task (≥ v0.136.0) */
+  | "followup_task"
   | "unknown";
 
 export interface CodexToolCall {

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -15,6 +15,8 @@ pub enum ToolKind {
     SpawnAgent,
     WaitAgent,
     CloseAgent,
+    /// multi-agent v2 task assignment: `assign_task` (Codex < v0.136.0) or `followup_task` (≥ v0.136.0)
+    FollowupTask,
     Unknown,
 }
 
@@ -236,6 +238,35 @@ impl ToolCallBuilder {
                     image_prompt: None,
                     worker_session: None,
                     status: spawn_agent_status(output),
+                });
+                return;
+            }
+
+            // assign_task (Codex < v0.136.0, PR #25267) was renamed to followup_task
+            // (Codex ≥ v0.136.0, PR #25636). Both represent the multi-agent v2 task
+            // assignment tool and are classified as FollowupTask.
+            if pending.name == "assign_task" || pending.name == "followup_task" {
+                self.finalized.push(ToolCall {
+                    call_id: call_id.to_string(),
+                    kind: ToolKind::FollowupTask,
+                    name: pending.name,
+                    arguments: pending.arguments,
+                    input_text: pending.input_text,
+                    output: Some(output.to_string()),
+                    exit_code: None,
+                    command: None,
+                    cwd: None,
+                    duration_secs: None,
+                    mcp_server: None,
+                    mcp_tool: None,
+                    plugin_id: None,
+                    patch_success: None,
+                    patch_changes: None,
+                    web_query: None,
+                    web_url: None,
+                    image_prompt: None,
+                    worker_session: None,
+                    status: "completed".to_string(),
                 });
                 return;
             }
@@ -1048,7 +1079,7 @@ fn extract_mcp_output(payload: &Value) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_exec_function_output, parse_mcp_namespace};
+    use super::{parse_exec_function_output, parse_mcp_namespace, ToolCallBuilder, ToolKind};
 
     #[test]
     fn namespace_with_tool_prefix_keeps_full_namespace_as_server() {
@@ -1122,6 +1153,49 @@ mod tests {
             tool.duration_secs.is_some(),
             "duration should be extracted from structured field"
         );
+    }
+
+    // Codex v0.136.0 (PR #25267) renamed the multi-agent v2 assignment tool from
+    // `assign_task` to `followup_task` (v0.137.0, PR #25636). Both names must be
+    // classified as FollowupTask so sessions from all versions display correctly.
+    #[test]
+    fn assign_task_legacy_classified_as_followup_task() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_assign".to_string(),
+            "assign_task".to_string(),
+            r#"{"message":"Please investigate the regression","agent":"worker-1"}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_assign", r#"{"status":"accepted"}"#);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::FollowupTask);
+        assert_eq!(tool.name, "assign_task");
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn followup_task_new_name_classified_as_followup_task() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_followup".to_string(),
+            "followup_task".to_string(),
+            r#"{"message":"Continue the analysis","agent":"worker-2"}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_followup", r#"{"status":"accepted"}"#);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::FollowupTask);
+        assert_eq!(tool.name, "followup_task");
+        assert_eq!(tool.status, "completed");
     }
 
     #[test]

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -53,6 +53,10 @@ export function CloseAgentIcon() {
   return <AiOutlineRobot className="icon--agents" />;
 }
 
+export function FollowupTaskIcon() {
+  return <AiOutlineRobot className="icon--agents" />;
+}
+
 export function UnknownToolIcon() {
   return <VscTriangleRight className="icon--tool" />;
 }

--- a/src/components/ToolCallItem.tsx
+++ b/src/components/ToolCallItem.tsx
@@ -11,6 +11,7 @@ import {
   SpawnIcon,
   WaitIcon,
   CloseAgentIcon,
+  FollowupTaskIcon,
   UnknownToolIcon,
   WarningIcon,
   PopoutIcon,
@@ -44,6 +45,8 @@ function kindIcon(kind: CodexToolCall["kind"], failed: boolean) {
       return <WaitIcon />;
     case "close_agent":
       return <CloseAgentIcon />;
+    case "followup_task":
+      return <FollowupTaskIcon />;
     default:
       return <UnknownToolIcon />;
   }
@@ -64,6 +67,7 @@ function kindClass(kind: CodexToolCall["kind"]): string {
     case "spawn_agent":
     case "wait_agent":
     case "close_agent":
+    case "followup_task":
       return "tool-call--collab";
     default:
       return "tool-call--unknown";
@@ -284,7 +288,10 @@ function ToolCallBody({ tool, popout = false }: { tool: CodexToolCall; popout?: 
         </div>
       )}
 
-      {(tool.kind === "spawn_agent" || tool.kind === "wait_agent" || tool.kind === "close_agent") &&
+      {(tool.kind === "spawn_agent" ||
+        tool.kind === "wait_agent" ||
+        tool.kind === "close_agent" ||
+        tool.kind === "followup_task") &&
         Object.keys(tool.arguments ?? {}).length > 0 && (
           <div className="tool-call__section tool-call__section--input">
             <div className="tool-call__section-title">Arguments</div>


### PR DESCRIPTION
## Summary

Codex v0.136.0 (PR #25267) renamed the multi-agent v2 assignment tool from `assign_task` to `followup_task` (finalised in v0.137.0, PR #25636). Sessions produced by Codex >= v0.136.0 emit `followup_task`; older sessions emit `assign_task`. Both were previously classified as `Unknown`, making the tool call invisible in multi-agent traces.

## Changes

**`src-tauri/src/parser/toolcall.rs`**
- Add `FollowupTask` variant to the `ToolKind` enum
- In `add_function_call_output`, handle both `assign_task` and `followup_task` by name, emitting `ToolKind::FollowupTask` for either — preserves the raw `name` field so callers can still distinguish versions if needed
- Add two unit tests covering both the legacy and new tool names

**`shared/types.ts`**
- Add `"followup_task"` to the `ToolKind` union type

**`src/components/Icons.tsx`**
- Add `FollowupTaskIcon` (reuses the agent robot icon, consistent with other collab tools)

**`src/components/ToolCallItem.tsx`**
- Wire `followup_task` into `kindIcon`, `kindClass` (renders in the `tool-call--collab` style group), and the arguments body section

## Testing

- `assign_task_legacy_classified_as_followup_task` — verifies Codex < v0.136.0 sessions classify correctly
- `followup_task_new_name_classified_as_followup_task` — verifies Codex >= v0.136.0 sessions classify correctly
- Full suite: 168 Rust tests pass, 128 frontend tests pass
- `cargo clippy -- -D warnings`, `oxlint`, `oxfmt`, `tsc --noEmit` all clean

Fixes #102
