### PR TITLE
fix(parser): transparently decompress zstd-compressed rollout files (Codex v0.137.0 compat)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -460,6 +460,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -532,6 +534,7 @@ dependencies = [
  "tokio-stream",
  "tower-http",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -2005,6 +2008,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -5826,6 +5839,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 indexmap = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
+zstd = "0.13"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src-tauri/src/parser/compression.rs
+++ b/src-tauri/src/parser/compression.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+// zstd frame magic: 0xFD2FB528 stored little-endian => bytes [0x28, 0xB5, 0x2F, 0xFD]
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Read a session file that may be plain text or zstd-compressed.
+/// Detects the zstd frame magic and decompresses transparently.
+pub fn read_session_file(path: &Path) -> Result<String, String> {
+    let bytes = std::fs::read(path).map_err(|e| e.to_string())?;
+    if bytes.starts_with(&ZSTD_MAGIC) {
+        let decompressed = zstd::decode_all(bytes.as_slice()).map_err(|e| format!("zstd: {e}"))?;
+        String::from_utf8(decompressed).map_err(|e| format!("zstd utf-8: {e}"))
+    } else {
+        String::from_utf8(bytes).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn compress_zstd(data: &[u8]) -> Vec<u8> {
+        zstd::encode_all(data, 3).expect("zstd compress failed")
+    }
+
+    #[test]
+    fn read_plain_text_unchanged() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("plain.jsonl");
+        let content = r#"{"type":"session_meta","payload":{"id":"abc"}}"#;
+        std::fs::write(&path, content).unwrap();
+        let result = read_session_file(&path).unwrap();
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn read_zstd_compressed_decompresses() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("compressed.jsonl");
+        let content = r#"{"type":"session_meta","payload":{"id":"compressed-session"}}"#;
+        let compressed = compress_zstd(content.as_bytes());
+        std::fs::write(&path, &compressed).unwrap();
+        let result = read_session_file(&path).unwrap();
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn read_zstd_multiline_jsonl() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("multi.jsonl");
+        let content = [
+            r#"{"timestamp":"2026-06-04T00:00:00Z","type":"session_meta","payload":{"id":"zstd-session","timestamp":"2026-06-04T00:00:00Z"}}"#,
+            r#"{"timestamp":"2026-06-04T00:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-06-04T00:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","completed_at":1748995202.0}}"#,
+        ]
+        .join("\n");
+        let compressed = compress_zstd(content.as_bytes());
+        std::fs::write(&path, &compressed).unwrap();
+        let result = read_session_file(&path).unwrap();
+        assert_eq!(result, content);
+    }
+}

--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 use std::time::SystemTime;
 
+use super::compression::read_session_file;
 use super::entry::{extract_session_id, RawEntry};
 use super::spawn::parse_spawn_agent_output;
 
@@ -115,7 +116,7 @@ fn date_group_from_path(path: &Path) -> String {
 
 /// Quickly scan a JSONL file for session metadata without full parsing.
 fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
-    let content = fs::read_to_string(path).ok()?;
+    let content = read_session_file(path).ok()?;
     let mut lines = content.lines().filter(|l| !l.trim().is_empty());
 
     let first_line = lines.next()?;
@@ -1051,5 +1052,76 @@ mod tests {
         assert_eq!(session.cli_version.as_deref(), Some("0.134.0"));
         assert_eq!(session.turn_count, 1);
         assert!(!session.is_ongoing);
+    }
+
+    // Codex v0.137.0 (PRs #25089, #25087): cold session rollout files are now stored
+    // compressed with zstd. discover_sessions must detect and decompress them transparently.
+
+    fn compress_zstd(data: &[u8]) -> Vec<u8> {
+        zstd::encode_all(data, 3).expect("zstd compress failed")
+    }
+
+    #[test]
+    fn discover_sessions_v0137_zstd_compressed_session() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/06/04");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-06-04T10-00-00-zstd.jsonl");
+        let content = [
+            r#"{"timestamp":"2026-06-04T10:00:00Z","type":"session_meta","payload":{"id":"v0137-disc-zstd","timestamp":"2026-06-04T10:00:00Z","cwd":"/project","cli_version":"0.137.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748995202.0}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, compress_zstd(content.as_bytes())).unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions.iter().find(|s| s.id == "v0137-disc-zstd").unwrap();
+        assert_eq!(session.cli_version.as_deref(), Some("0.137.0"));
+        assert_eq!(session.turn_count, 1);
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn discover_sessions_v0137_plain_and_compressed_coexist() {
+        // Mixed directory: some plain, some compressed — both must be discovered correctly.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/06/04");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let plain_path = day_dir.join("rollout-2026-06-04T09-00-00-plain.jsonl");
+        std::fs::write(
+            &plain_path,
+            [
+                r#"{"timestamp":"2026-06-04T09:00:00Z","type":"session_meta","payload":{"id":"v0136-plain","timestamp":"2026-06-04T09:00:00Z","cli_version":"0.136.0"}}"#,
+                r#"{"timestamp":"2026-06-04T09:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#,
+                r#"{"timestamp":"2026-06-04T09:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","completed_at":1748991602.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let compressed_path = day_dir.join("rollout-2026-06-04T10-00-00-compressed.jsonl");
+        let compressed_content = [
+            r#"{"timestamp":"2026-06-04T10:00:00Z","type":"session_meta","payload":{"id":"v0137-compressed","timestamp":"2026-06-04T10:00:00Z","cli_version":"0.137.0"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","completed_at":1748995202.0}}"#,
+        ]
+        .join("\n");
+        std::fs::write(
+            &compressed_path,
+            compress_zstd(compressed_content.as_bytes()),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        assert!(
+            sessions.iter().any(|s| s.id == "v0136-plain"),
+            "plain session must be found"
+        );
+        assert!(
+            sessions.iter().any(|s| s.id == "v0137-compressed"),
+            "compressed session must be found"
+        );
     }
 }

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod compression;
 pub mod discover;
 pub mod entry;
 pub mod ongoing;

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::fs;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use super::compression::read_session_file;
 use super::entry::{extract_session_id, RawEntry};
 use super::toolcall::ToolKind;
 use super::turn::{build_turns, CodexTurn, TokenInfo, TurnStatus};
@@ -49,7 +49,7 @@ fn parse_session_inner(
     path: &Path,
     visited: &mut HashSet<PathBuf>,
 ) -> Result<CodexSession, String> {
-    let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let content = read_session_file(path)?;
     let canonical_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     if !visited.insert(canonical_path.clone()) {
         return Err(format!(
@@ -223,10 +223,9 @@ fn find_session_file_by_id(anchor_path: &Path, session_id: &str) -> Option<PathB
 }
 
 fn session_file_id(path: &Path) -> Option<String> {
-    let file = fs::File::open(path).ok()?;
-    BufReader::new(file).lines().take(20).find_map(|line| {
-        let line = line.ok()?;
-        let entry = RawEntry::parse(&line)?;
+    let content = read_session_file(path).ok()?;
+    content.lines().take(20).find_map(|line| {
+        let entry = RawEntry::parse(line)?;
         match entry.entry_type.as_str() {
             "session_meta" => {
                 let id = extract_session_id(&entry.payload);
@@ -980,6 +979,61 @@ mod tests {
                 "Project uses TypeScript strict mode"
             ]
         );
+        assert!(!session.is_ongoing);
+    }
+
+    // Codex v0.137.0 (PRs #25089, #25087): cold session rollout files are now stored
+    // compressed with zstd. parse_session must detect the magic bytes and decompress
+    // transparently before parsing.
+
+    fn compress_zstd(data: &[u8]) -> Vec<u8> {
+        zstd::encode_all(data, 3).expect("zstd compress failed")
+    }
+
+    #[test]
+    fn v0137_parse_session_from_zstd_compressed_file() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-06-04T10-00-00-v0137compressed.jsonl");
+        let content = [
+            r#"{"timestamp":"2026-06-04T10:00:00Z","type":"session_meta","payload":{"id":"v0137-zstd-session","timestamp":"2026-06-04T10:00:00Z","cwd":"/project","cli_version":"0.137.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello from compressed session"}}"#,
+            r#"{"timestamp":"2026-06-04T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748995203.0}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&path, compress_zstd(content.as_bytes())).unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0137-zstd-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.137.0"));
+        assert_eq!(session.turns.len(), 1);
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn v0137_parse_session_plain_still_works() {
+        // Non-compressed files from older Codex versions must continue to parse correctly.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-06-04T10-01-00-v0136plain.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-06-04T10:01:00Z","type":"session_meta","payload":{"id":"v0136-plain-session","timestamp":"2026-06-04T10:01:00Z","cwd":"/project","cli_version":"0.136.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-06-04T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-06-04T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748995262.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0136-plain-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.136.0"));
+        assert_eq!(session.turns.len(), 1);
         assert!(!session.is_ongoing);
     }
 


### PR DESCRIPTION
## Problem

Codex v0.137.0 ([rust-v0.137.0 release](https://github.com/openai/codex/releases/tag/rust-v0.137.0)) introduced two PRs that store cold-session rollout files compressed on disk:

- `#25089 Compress cold local rollouts` — cold session transcripts are now written as zstd-compressed files
- `#25087 Read compressed rollouts and materialize before append` — Codex transparently decompresses on its own reads

codex-trace reads these files directly with `fs::read_to_string` / `BufReader`, bypassing Codex's decompression layer entirely. The result: every session created with Codex ≥ v0.137.0 reads as garbled bytes and produces JSON parse errors on every line — a silent data-loss scenario where traces appear empty.

## Fix

Added `src-tauri/src/parser/compression.rs` — a `read_session_file(path)` helper that:

1. Reads the raw file bytes
2. Checks for the zstd frame magic (`0x28 0xB5 0x2F 0xFD`, the little-endian encoding of `0xFD2FB528`)
3. If compressed: decompresses with `zstd::decode_all` then decodes UTF-8
4. Otherwise: falls back to plain UTF-8 (identical to prior behaviour)

All three read sites are updated to use this helper:

- `parse_session_inner` in `session.rs` — full session parse
- `session_file_id` in `session.rs` — worker session ID lookup (also removes the now-unnecessary `BufReader` import)
- `scan_session_file` in `discover.rs` — lightweight metadata scan

## Testing

- **`compression.rs`**: 3 new unit tests (plain text passthrough, single-line zstd, multi-line zstd JSONL)
- **`session.rs`**: 2 new integration tests (`v0137_parse_session_from_zstd_compressed_file`, `v0137_parse_session_plain_still_works`)
- **`discover.rs`**: 2 new integration tests (`discover_sessions_v0137_zstd_compressed_session`, `discover_sessions_v0137_plain_and_compressed_coexist`)

Full suite: **173 Rust tests pass**, **128 frontend tests pass**. `cargo clippy -D warnings` and `cargo fmt --check` both clean.

Fixes #101
