### PR TITLE
feat(parser): add compaction_trigger to CompactionMeta (Codex v0.135.0 compat)

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -29,6 +29,8 @@ export interface CompactionMeta {
   tokens_after: number | null;
   /** Optional human-readable summary of what was compacted. */
   summary: string | null;
+  /** What triggered the compaction: `"auto"` (threshold-based) or `"manual"` (user-requested). Null for sessions that predate this field. */
+  compaction_trigger: string | null;
 }
 
 export interface CollabSpawn {

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -46,6 +46,9 @@ pub struct CompactionMeta {
     pub tokens_after: Option<u64>,
     /// Optional human-readable summary of what was compacted.
     pub summary: Option<String>,
+    /// What triggered the compaction: `"auto"` (threshold-based) or `"manual"` (user-requested).
+    /// Null for sessions that predate this field.
+    pub compaction_trigger: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -249,6 +252,11 @@ fn handle_event_msg(
                 tokens_after: c.get("tokens_after").and_then(|v| v.as_u64()),
                 summary: c
                     .get("summary")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string()),
+                compaction_trigger: c
+                    .get("compaction_trigger")
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string()),
@@ -2379,6 +2387,49 @@ mod tests {
         assert_eq!(meta.tokens_before, Some(120000));
         assert_eq!(meta.tokens_after, Some(45000));
         assert_eq!(meta.summary.as_deref(), Some("Summarised earlier turns"));
+        assert!(
+            meta.compaction_trigger.is_none(),
+            "compaction_trigger absent from payload must be None"
+        );
+    }
+
+    #[test]
+    fn v0135_compaction_trigger_auto_is_captured() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-28T11:00:00Z","type":"session_meta","payload":{"id":"v0135-ctrigger-auto","timestamp":"2026-05-28T11:00:00Z","cli_version":"0.135.0"}}"#,
+            r#"{"timestamp":"2026-05-28T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","compaction":{"tokens_before":200000,"tokens_after":60000,"compaction_trigger":"auto"}}}"#,
+            r#"{"timestamp":"2026-05-28T11:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748430002.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        let meta = turns[0]
+            .compaction_meta
+            .as_ref()
+            .expect("compaction_meta must be present");
+        assert_eq!(meta.compaction_trigger.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn v0135_compaction_trigger_manual_is_captured() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-28T11:00:00Z","type":"session_meta","payload":{"id":"v0135-ctrigger-manual","timestamp":"2026-05-28T11:00:00Z","cli_version":"0.135.0"}}"#,
+            r#"{"timestamp":"2026-05-28T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","compaction":{"tokens_before":150000,"tokens_after":50000,"summary":"User-requested compaction","compaction_trigger":"manual"}}}"#,
+            r#"{"timestamp":"2026-05-28T11:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748430002.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        let meta = turns[0]
+            .compaction_meta
+            .as_ref()
+            .expect("compaction_meta must be present");
+        assert_eq!(meta.compaction_trigger.as_deref(), Some("manual"));
+        assert_eq!(meta.summary.as_deref(), Some("User-requested compaction"));
+        assert_eq!(meta.tokens_before, Some(150000));
+        assert_eq!(meta.tokens_after, Some(50000));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds the `compaction_trigger` field to `CompactionMeta`, completing the turn-header compaction metadata introduced in Codex v0.135.0 (PR #24368).

PR #94 already captured `tokens_before`, `tokens_after`, and `summary` but omitted the `compaction_trigger` field that distinguishes **auto** (threshold-based) compaction from **manual** (user-requested) compaction. Sessions from Codex ≥ 0.135.0 that include this field would previously have it silently dropped.

## Changes

### `src-tauri/src/parser/turn.rs`
- Added `compaction_trigger: Option<String>` to `CompactionMeta` struct
- Parses `compaction.compaction_trigger` from `task_started` event payloads
- 3 new regression tests:
  - `v0135_compaction_meta_in_task_started_is_captured` — extended to assert trigger is `None` when absent
  - `v0135_compaction_trigger_auto_is_captured` — round-trip for `"auto"` trigger
  - `v0135_compaction_trigger_manual_is_captured` — round-trip for `"manual"` trigger with all other fields

### `shared/types.ts`
- Added `compaction_trigger: string | null` to `CompactionMeta` interface (mirrors Rust struct)

## Verification

- `cargo test --lib`: 168/168 pass (including 2 new compaction_trigger tests)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `npx tsc --noEmit`: clean
- `npx vitest run`: 128/128 pass
- HTTP API (`GET /api/sessions`): OK

Fixes #105
