### PR TITLE
[#106]: Fix image_generation tool calls classified as Unknown in Codex v0.135.0+

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -694,4 +694,53 @@ mod tests {
         let meta = RawEntry::parse(lines[0]).unwrap();
         assert_eq!(meta.payload["cli_version"], "0.135.0");
     }
+
+    // Codex v0.135.0 (PR #24652): plain image wrapper spans removed from session output.
+    // Before v0.135.0, image content in function_call_output and message response_items was
+    // wrapped in {"type":"image_span","content":[...]}. v0.135.0+ emits bare image items
+    // such as {"type":"image_url","image_url":{"url":"..."}}. The RawEntry parser must pass
+    // through both formats without panicking; downstream classification is in toolcall.rs.
+
+    #[test]
+    fn v0135_function_call_output_with_bare_image_item_does_not_panic() {
+        // v0.135.0+: image_generation output carries a bare image_url item (no image_span wrapper).
+        let line = r#"{"timestamp":"2026-05-28T10:00:05Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_img","output":[{"type":"image_url","image_url":{"url":"data:image/png;base64,abc123"}}]}}"#;
+        let e = RawEntry::parse(line).expect("function_call_output with bare image_url must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "function_call_output");
+        assert_eq!(e.payload["call_id"], "call_img");
+        // The output array is accessible and contains one image_url item.
+        let output_arr = e.payload["output"]
+            .as_array()
+            .expect("output must be array");
+        assert_eq!(output_arr.len(), 1);
+        assert_eq!(output_arr[0]["type"], "image_url");
+    }
+
+    #[test]
+    fn v0135_image_generation_session_parses_correctly() {
+        // Full v0.135.0 session with an image_generation tool call.
+        // function_call output contains bare image_url items (no image_span wrapper).
+        let lines = [
+            r#"{"timestamp":"2026-05-28T10:00:00Z","type":"session_meta","payload":{"id":"v0135-img-session","timestamp":"2026-05-28T10:00:00Z","cwd":"/project","cli_version":"0.135.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"image_generation","call_id":"call_img","arguments":"{\"prompt\":\"a sunset over mountains\"}"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_img","output":[{"type":"image_url","image_url":{"url":"data:image/png;base64,abc123"}}]}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748426404.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "response_item",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.135.0");
+        assert_eq!(meta.payload["id"], "v0135-img-session");
+    }
 }

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -214,6 +214,46 @@ impl ToolCallBuilder {
                 return;
             }
 
+            // Codex v0.135.0 (PR #24652): plain image wrapper spans removed from session
+            // output. Image content is now emitted bare (e.g. {"type":"image_url",...})
+            // rather than wrapped in {"type":"image_span","content":[...]}. Detect
+            // image_generation by function name and extract the prompt from arguments —
+            // never rely on the wrapper span type, which no longer exists in v0.135.0+.
+            if pending.name == "image_generation" {
+                let image_prompt = pending
+                    .arguments
+                    .get("prompt")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                self.finalized.push(ToolCall {
+                    call_id: call_id.to_string(),
+                    kind: ToolKind::ImageGeneration,
+                    name: pending.name,
+                    arguments: pending.arguments,
+                    input_text: pending.input_text,
+                    output: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.to_string())
+                    },
+                    exit_code: None,
+                    command: None,
+                    cwd: None,
+                    duration_secs: None,
+                    mcp_server: None,
+                    mcp_tool: None,
+                    plugin_id: None,
+                    patch_success: None,
+                    patch_changes: None,
+                    web_query: None,
+                    web_url: None,
+                    image_prompt,
+                    worker_session: None,
+                    status: "completed".to_string(),
+                });
+                return;
+            }
+
             if pending.name == "spawn_agent" {
                 self.finalized.push(ToolCall {
                     call_id: call_id.to_string(),
@@ -1149,5 +1189,88 @@ mod tests {
             !old_out.contains("research preview"),
             "banner text leaked into output"
         );
+    }
+
+    // Codex v0.135.0 (PR #24652): plain image wrapper spans removed from session output.
+    // Image content is now emitted bare (e.g. {"type":"image_url",...}) rather than wrapped
+    // in {"type":"image_span","content":[...]}. The image_generation function call must be
+    // classified as ImageGeneration with image_prompt extracted from arguments — never from
+    // the output content, since image data is not stored in the text output field.
+
+    #[test]
+    fn image_generation_classified_as_image_generation_kind() {
+        use super::super::super::parser::toolcall::{ToolCallBuilder, ToolKind};
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_img".to_string(),
+            "image_generation".to_string(),
+            r#"{"prompt":"a sunset over mountains","size":"1024x1024"}"#,
+            None,
+            None,
+            None,
+        );
+
+        // v0.135.0+: output is a bare image_url item (no image_span wrapper).
+        // The text extraction from the content array yields an empty string —
+        // the prompt comes from arguments, not the output.
+        builder.add_function_call_output("call_img", "");
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ImageGeneration);
+        assert_eq!(
+            tool.image_prompt.as_deref(),
+            Some("a sunset over mountains")
+        );
+        assert_eq!(tool.status, "completed");
+        assert!(
+            tool.output.is_none(),
+            "empty output string should yield None"
+        );
+    }
+
+    #[test]
+    fn image_generation_with_no_prompt_argument_yields_none_image_prompt() {
+        use super::super::super::parser::toolcall::{ToolCallBuilder, ToolKind};
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_img2".to_string(),
+            "image_generation".to_string(),
+            r#"{"size":"512x512"}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_img2", "");
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ImageGeneration);
+        assert!(tool.image_prompt.is_none());
+    }
+
+    #[test]
+    fn image_generation_with_non_empty_output_preserves_output() {
+        use super::super::super::parser::toolcall::{ToolCallBuilder, ToolKind};
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_img3".to_string(),
+            "image_generation".to_string(),
+            r#"{"prompt":"a mountain lake"}"#,
+            None,
+            None,
+            None,
+        );
+        // If upstream text extraction yields something (future format), preserve it.
+        builder.add_function_call_output("call_img3", "Generated image successfully");
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ImageGeneration);
+        assert_eq!(tool.image_prompt.as_deref(), Some("a mountain lake"));
+        assert_eq!(tool.output.as_deref(), Some("Generated image successfully"));
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -2478,4 +2478,59 @@ mod tests {
             vec!["Initial memory", "New memory added"]
         );
     }
+
+    // Codex v0.135.0 (PR #24652): plain image wrapper spans removed from session output.
+    // image_generation function calls must be classified as ImageGeneration with image_prompt
+    // extracted from arguments. The output array may contain bare image_url items (v0.135.0+)
+    // rather than image_span wrappers — the parser must not look for image_span.
+
+    #[test]
+    fn v0135_image_generation_tool_call_classified_as_image_generation() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-28T10:00:00Z","type":"session_meta","payload":{"id":"v0135-img","timestamp":"2026-05-28T10:00:00Z","cli_version":"0.135.0"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"image_generation","call_id":"call_img","arguments":"{\"prompt\":\"a sunset over mountains\"}"}}"#,
+            // v0.135.0+: output is a bare image_url item — no image_span wrapper.
+            r#"{"timestamp":"2026-05-28T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_img","output":[{"type":"image_url","image_url":{"url":"data:image/png;base64,abc123"}}]}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748426404.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.kind, ToolKind::ImageGeneration);
+        assert_eq!(
+            tool.image_prompt.as_deref(),
+            Some("a sunset over mountains")
+        );
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn v0135_image_generation_without_wrapper_span_does_not_yield_unknown_kind() {
+        // Before v0.135.0, an image_span wrapper might have been present. With v0.135.0,
+        // it is absent. The kind must be ImageGeneration regardless of output format.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-28T10:00:00Z","type":"session_meta","payload":{"id":"v0135-img2","timestamp":"2026-05-28T10:00:00Z","cli_version":"0.135.0"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"image_generation","call_id":"call_img2","arguments":"{\"prompt\":\"a mountain lake\",\"size\":\"1024x1024\"}"}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_img2","output":[{"type":"image_url","image_url":{"url":"data:image/png;base64,xyz"}}]}}"#,
+            r#"{"timestamp":"2026-05-28T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748426404.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+
+        let tool = &turns[0].tool_calls[0];
+        assert_ne!(
+            tool.kind,
+            ToolKind::Unknown,
+            "image_generation must not be Unknown"
+        );
+        assert_eq!(tool.kind, ToolKind::ImageGeneration);
+        assert_eq!(tool.image_prompt.as_deref(), Some("a mountain lake"));
+    }
 }


### PR DESCRIPTION
## Summary

Codex v0.135.0 (PR #24652) removed the `image_span` wrapper elements that previously surrounded plain image content in session JSONL output. Images are now emitted bare:

**Before v0.135.0:**
```json
{"type":"image_span","content":[{"type":"image_url","image_url":{"url":"..."}}]}
```

**v0.135.0+:**
```json
{"type":"image_url","image_url":{"url":"..."}}
```

The `ToolKind::ImageGeneration` variant and `image_prompt` field already existed in the Rust structs, but no code path in `add_function_call_output` ever populated them. All `image_generation` function calls silently fell through to `ToolKind::Unknown`, so the frontend never received kind or prompt data for image tool calls.

## Fix

Added detection for `image_generation` by function name in `add_function_call_output` (`toolcall.rs`). The prompt is extracted from the function arguments (`"prompt"` key) — not from the output content array. This approach is robust against any output format changes (including the span wrapper removal) since it never relies on the output content type.

## Files Changed

- `src-tauri/src/parser/toolcall.rs` — core fix: detect `image_generation` by name, emit `ToolKind::ImageGeneration` with `image_prompt` from arguments; 3 new unit tests
- `src-tauri/src/parser/entry.rs` — 2 compat tests: `function_call_output` with bare `image_url` item parses without panic; full v0.135.0 session with image_generation parses correctly
- `src-tauri/src/parser/turn.rs` — 2 end-to-end integration tests: full session → `build_turns` → verify `kind == ImageGeneration` and `image_prompt` is populated; verify kind is never `Unknown`

## Test Results

- 173 Rust tests: PASS
- 128 frontend tests: PASS
- `cargo clippy -- -D warnings`: PASS
- `cargo fmt --check`: PASS
- `tsc --noEmit`: PASS
- HTTP API smoke test: OK

Fixes #106
