### PR TITLE
[#104]: Support shell_hook_output events for Codex v0.136.0 strict schema

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -50,6 +50,8 @@ export type ToolKind =
   | "spawn_agent"
   | "wait_agent"
   | "close_agent"
+  /** Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks. */
+  | "shell_hook"
   | "unknown";
 
 export interface CodexToolCall {

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -694,4 +694,62 @@ mod tests {
         let meta = RawEntry::parse(lines[0]).unwrap();
         assert_eq!(meta.payload["cli_version"], "0.135.0");
     }
+
+    // Codex v0.136.0 (PR #24962): shell hook output event schemas tightened.
+    // hook output events are now emitted as event_msg entries with type "shell_hook_output".
+    // The strict schema requires call_id, hook_type, stdout, exit_code; previously nullable
+    // fields (metadata, stderr) are absent rather than null. RawEntry must parse these
+    // as event_msg entries without error.
+
+    #[test]
+    fn v0136_shell_hook_output_parses_as_event_msg() {
+        // v0.136.0 strict schema — no metadata, no stderr fields
+        let line = r#"{"timestamp":"2026-06-01T10:00:00Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-1","hook_type":"pre_exec","stdout":"hook ok\n","exit_code":0,"duration":{"secs":0,"nanos":5000000}}}"#;
+        let e = RawEntry::parse(line).expect("shell_hook_output event must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(event_msg_type(&e.payload), Some("shell_hook_output"));
+        assert_eq!(e.payload["hook_type"], "pre_exec");
+        assert_eq!(e.payload["exit_code"], 0);
+    }
+
+    #[test]
+    fn v0136_shell_hook_output_absent_nullable_fields_does_not_panic() {
+        // v0.136.0 tightening: metadata and stderr are absent (not null).
+        // Verify that RawEntry parsing does not panic on the minimal strict payload.
+        let line = r#"{"timestamp":"2026-06-01T10:01:00Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-min","hook_type":"post_mcp","stdout":"","exit_code":0}}"#;
+        let e = RawEntry::parse(line).expect("minimal shell_hook_output must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(event_msg_type(&e.payload), Some("shell_hook_output"));
+        // These fields are absent in the v0.136.0 strict schema — must not be present
+        assert!(e.payload.get("metadata").is_none());
+        assert!(e.payload.get("stderr").is_none());
+    }
+
+    #[test]
+    fn v0136_all_standard_entry_types_parse_correctly() {
+        // Regression guard: all standard entry types plus shell_hook_output must parse
+        // correctly for a v0.136.0 session.
+        let lines = [
+            r#"{"timestamp":"2026-06-01T10:02:00Z","type":"session_meta","payload":{"id":"v0136-session","timestamp":"2026-06-01T10:02:00Z","cwd":"/project","cli_version":"0.136.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:04Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-v0136","hook_type":"pre_exec","stdout":"ok\n","exit_code":0}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748779325.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.136.0");
+    }
 }

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -15,6 +15,8 @@ pub enum ToolKind {
     SpawnAgent,
     WaitAgent,
     CloseAgent,
+    /// Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks.
+    ShellHook,
     Unknown,
 }
 
@@ -651,6 +653,55 @@ impl ToolCallBuilder {
         });
     }
 
+    /// Finalize a shell_hook_output event (Codex v0.136.0, PR #24962).
+    ///
+    /// The v0.136.0 tightened schema requires: call_id, hook_type, stdout, exit_code.
+    /// Fields that were previously null (metadata, stderr) are now absent — read only
+    /// the stable fields so older null-padded payloads also parse correctly.
+    pub fn finalize_shell_hook(&mut self, payload: &Value) {
+        let call_id = str_field(payload, "call_id");
+        let hook_type = str_field(payload, "hook_type");
+        let stdout = payload
+            .get("stdout")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+        let exit_code = payload
+            .get("exit_code")
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32);
+        let duration_secs = parse_duration(payload);
+        let status = if exit_code.map(|c| c != 0).unwrap_or(false) {
+            "failed"
+        } else {
+            "completed"
+        }
+        .to_string();
+
+        self.finalized.push(ToolCall {
+            call_id,
+            kind: ToolKind::ShellHook,
+            name: hook_type,
+            arguments: Value::Object(serde_json::Map::new()),
+            input_text: None,
+            output: stdout,
+            exit_code,
+            command: None,
+            cwd: None,
+            duration_secs,
+            mcp_server: None,
+            mcp_tool: None,
+            plugin_id: None,
+            patch_success: None,
+            patch_changes: None,
+            web_query: None,
+            web_url: None,
+            image_prompt: None,
+            worker_session: None,
+            status,
+        });
+    }
+
     /// Catch-all for any unrecognised *_end event — preserves name from pending.
     pub fn finalize_unknown_end(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
@@ -1048,7 +1099,8 @@ fn extract_mcp_output(payload: &Value) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_exec_function_output, parse_mcp_namespace};
+    use super::{parse_exec_function_output, parse_mcp_namespace, ToolCallBuilder, ToolKind};
+    use serde_json::json;
 
     #[test]
     fn namespace_with_tool_prefix_keeps_full_namespace_as_server() {
@@ -1090,9 +1142,6 @@ mod tests {
     // must not require `formatted_output` to be present.
     #[test]
     fn exec_command_end_v0132_reads_aggregated_output_without_formatted_output() {
-        use super::super::super::parser::toolcall::ToolCallBuilder;
-        use serde_json::json;
-
         let mut builder = ToolCallBuilder::new();
         builder.add_function_call(
             "call_1".to_string(),
@@ -1149,5 +1198,76 @@ mod tests {
             !old_out.contains("research preview"),
             "banner text leaked into output"
         );
+    }
+
+    // Codex v0.136.0 (PR #24962): shell hook output events with the tightened schema.
+    // The v0.136.0 schema enforces: call_id, hook_type, stdout, exit_code.
+    // Fields previously present as null (metadata, stderr) are now absent entirely.
+
+    #[test]
+    fn shell_hook_output_v0136_pre_exec_classified_as_shell_hook() {
+        let mut builder = ToolCallBuilder::new();
+        // v0.136.0 strict schema: no metadata or stderr fields
+        let payload = json!({
+            "call_id": "hook-call-1",
+            "hook_type": "pre_exec",
+            "stdout": "hook ran ok\n",
+            "exit_code": 0,
+            "duration": {"secs": 0, "nanos": 5_000_000u64}
+        });
+        builder.finalize_shell_hook(&payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tc = &builder.finalized[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.call_id, "hook-call-1");
+        assert_eq!(tc.name, "pre_exec");
+        assert_eq!(tc.output.as_deref(), Some("hook ran ok\n"));
+        assert_eq!(tc.exit_code, Some(0));
+        assert_eq!(tc.status, "completed");
+        assert!(tc.duration_secs.is_some());
+    }
+
+    #[test]
+    fn shell_hook_output_v0136_post_exec_failed_hook() {
+        let mut builder = ToolCallBuilder::new();
+        let payload = json!({
+            "call_id": "hook-call-2",
+            "hook_type": "post_exec",
+            "stdout": "hook failed with error\n",
+            "exit_code": 1,
+            "duration": {"secs": 0, "nanos": 2_000_000u64}
+        });
+        builder.finalize_shell_hook(&payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tc = &builder.finalized[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "post_exec");
+        assert_eq!(tc.exit_code, Some(1));
+        assert_eq!(tc.status, "failed");
+    }
+
+    #[test]
+    fn shell_hook_output_v0136_absent_fields_not_null() {
+        // v0.136.0 tightening: previously-null fields (metadata, stderr) are now absent.
+        // Verify finalize_shell_hook does not panic when those fields are absent.
+        let mut builder = ToolCallBuilder::new();
+        let payload = json!({
+            "call_id": "hook-call-3",
+            "hook_type": "pre_mcp",
+            "stdout": "",
+            "exit_code": 0
+            // no duration, no metadata, no stderr — strict v0.136.0 schema
+        });
+        builder.finalize_shell_hook(&payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tc = &builder.finalized[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "pre_mcp");
+        assert!(tc.output.is_none()); // empty stdout → None
+        assert!(tc.duration_secs.is_none());
+        assert_eq!(tc.status, "completed");
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -579,6 +579,19 @@ fn handle_event_msg(
             }
         }
 
+        // Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks.
+        // The tightened schema requires call_id, hook_type, stdout, and exit_code; previously
+        // nullable fields (metadata, stderr) are now absent rather than null. Parse only the
+        // stable v0.136.0 fields so both old and new payloads deserialize correctly.
+        "shell_hook_output" => {
+            if let Some(ref tid) = current_turn_id {
+                let builder = tool_builders
+                    .entry(tid.clone())
+                    .or_insert_with(ToolCallBuilder::new);
+                builder.finalize_shell_hook(payload);
+            }
+        }
+
         "thread_name_updated" => {
             if let Some(ref tid) = current_turn_id {
                 if let Some(turn) = turns.get_mut(tid) {
@@ -2477,5 +2490,119 @@ mod tests {
             turns[1].memories,
             vec!["Initial memory", "New memory added"]
         );
+    }
+
+    // Codex v0.136.0 (PR #24962): shell hook output events with tightened schemas.
+    //
+    // PR #24962 enforced a strict contract on hook output event payloads. Previously the
+    // payload could carry nullable extra fields (e.g. `metadata`, `stderr`); the new schema
+    // removes those fields entirely (absent, not null). codex-trace must parse these events
+    // as ShellHook ToolCall entries and must not panic when the previously-nullable fields
+    // are absent.
+
+    #[test]
+    fn v0136_shell_hook_output_pre_exec_parsed_as_shell_hook_tool_call() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-06-01T10:00:00Z","type":"session_meta","payload":{"id":"v0136-hook","timestamp":"2026-06-01T10:00:00Z","cli_version":"0.136.0"}}"#,
+            r#"{"timestamp":"2026-06-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-01T10:00:02Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-abc","hook_type":"pre_exec","stdout":"pre-hook ran\n","exit_code":0,"duration":{"secs":0,"nanos":4000000}}}"#,
+            r#"{"timestamp":"2026-06-01T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748779203.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tc = &turns[0].tool_calls[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.call_id, "hook-abc");
+        assert_eq!(tc.name, "pre_exec");
+        assert_eq!(tc.output.as_deref(), Some("pre-hook ran\n"));
+        assert_eq!(tc.exit_code, Some(0));
+        assert_eq!(tc.status, "completed");
+        assert!(tc.duration_secs.is_some());
+    }
+
+    #[test]
+    fn v0136_shell_hook_output_post_exec_failed_is_status_failed() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-06-01T10:01:00Z","type":"session_meta","payload":{"id":"v0136-hook-fail","timestamp":"2026-06-01T10:01:00Z","cli_version":"0.136.0"}}"#,
+            r#"{"timestamp":"2026-06-01T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-01T10:01:02Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-fail-1","hook_type":"post_exec","stdout":"hook error output\n","exit_code":1,"duration":{"secs":0,"nanos":2000000}}}"#,
+            r#"{"timestamp":"2026-06-01T10:01:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748779263.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tc = &turns[0].tool_calls[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "post_exec");
+        assert_eq!(tc.exit_code, Some(1));
+        assert_eq!(tc.status, "failed");
+    }
+
+    #[test]
+    fn v0136_shell_hook_output_absent_nullable_fields_does_not_panic() {
+        // v0.136.0 tightening: metadata and stderr are absent (not null). Verify the parser
+        // handles the strictly-shaped payload without panicking or producing garbage data.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-06-01T10:02:00Z","type":"session_meta","payload":{"id":"v0136-hook-tight","timestamp":"2026-06-01T10:02:00Z","cli_version":"0.136.0"}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            // strict v0.136.0 schema: no metadata, no stderr, no duration
+            r#"{"timestamp":"2026-06-01T10:02:02Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-tight","hook_type":"pre_mcp","stdout":"","exit_code":0}}"#,
+            r#"{"timestamp":"2026-06-01T10:02:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748779323.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tc = &turns[0].tool_calls[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "pre_mcp");
+        assert!(tc.output.is_none()); // empty stdout → None
+        assert!(tc.duration_secs.is_none());
+        assert_eq!(tc.status, "completed");
+    }
+
+    #[test]
+    fn v0136_all_standard_entry_types_parse_correctly_with_shell_hook() {
+        // Regression guard: all four standard JSONL entry types plus shell_hook_output must
+        // parse correctly for a v0.136.0 session.
+        let lines = [
+            r#"{"timestamp":"2026-06-01T10:03:00Z","type":"session_meta","payload":{"id":"v0136-session","timestamp":"2026-06-01T10:03:00Z","cwd":"/project","cli_version":"0.136.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-01T10:03:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-01T10:03:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-06-01T10:03:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-01T10:03:04Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-v0136","hook_type":"pre_exec","stdout":"hook ok\n","exit_code":0,"duration":{"secs":0,"nanos":3000000}}}"#,
+            r#"{"timestamp":"2026-06-01T10:03:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748779385.0}}"#,
+        ];
+        let expected_entry_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+            "event_msg",
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        for (entry, expected) in parsed.iter().zip(expected_entry_types.iter()) {
+            assert_eq!(
+                entry.entry_type, *expected,
+                "wrong type for: {}",
+                entry.entry_type
+            );
+        }
+
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Complete);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        assert_eq!(turns[0].tool_calls[0].kind, ToolKind::ShellHook);
     }
 }

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -15,6 +15,7 @@ import {
   VscLightbulbEmpty,
   VscLinkExternal,
   VscClose,
+  VscBeaker,
 } from "react-icons/vsc";
 import { MdOutlineGeneratingTokens, MdOutlineImage } from "react-icons/md";
 import { GoGitMerge } from "react-icons/go";
@@ -107,4 +108,8 @@ export function PopoutIcon() {
 
 export function CloseIcon() {
   return <VscClose />;
+}
+
+export function HookIcon() {
+  return <VscBeaker className="icon--hook" />;
 }

--- a/src/components/ToolCallItem.tsx
+++ b/src/components/ToolCallItem.tsx
@@ -11,6 +11,7 @@ import {
   SpawnIcon,
   WaitIcon,
   CloseAgentIcon,
+  HookIcon,
   UnknownToolIcon,
   WarningIcon,
   PopoutIcon,
@@ -44,6 +45,8 @@ function kindIcon(kind: CodexToolCall["kind"], failed: boolean) {
       return <WaitIcon />;
     case "close_agent":
       return <CloseAgentIcon />;
+    case "shell_hook":
+      return <HookIcon />;
     default:
       return <UnknownToolIcon />;
   }
@@ -65,6 +68,8 @@ function kindClass(kind: CodexToolCall["kind"]): string {
     case "wait_agent":
     case "close_agent":
       return "tool-call--collab";
+    case "shell_hook":
+      return "tool-call--hook";
     default:
       return "tool-call--unknown";
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2994,6 +2994,9 @@ body {
 .tool-call--collab .tool-call__kind {
   color: var(--collab-badge);
 }
+.tool-call--hook .tool-call__kind {
+  color: var(--icon-hook);
+}
 .tool-call--failed {
   border-color: var(--status-error);
 }
@@ -3236,6 +3239,9 @@ body {
 }
 .tool-call--collab .tool-call__icon {
   color: var(--collab-badge);
+}
+.tool-call--hook .tool-call__icon {
+  color: var(--icon-hook);
 }
 .tool-call__section {
   margin-bottom: 10px;


### PR DESCRIPTION
## Summary

Fixes #104

Codex v0.136.0 (PR #24962 "Tighten hook output event schemas") made `shell_hook_output` event payloads stricter: previously-nullable fields (`metadata`, `stderr`) are now absent rather than null, and hook lifecycle events are emitted as `event_msg` entries with type `"shell_hook_output"`. Without this fix, codex-trace silently drops all hook tool calls from v0.136.0 sessions.

## Changes

### Rust parser (`src-tauri/src/parser/`)
- **`toolcall.rs`**: Added `ShellHook` variant to `ToolKind` enum. Added `ToolCallBuilder::finalize_shell_hook` which reads only the stable v0.136.0 fields (`call_id`, `hook_type`, `stdout`, `exit_code`, `duration`) — this makes the parser forward-compatible with both the old null-padded and new strict schemas.
- **`turn.rs`**: Added `"shell_hook_output"` dispatch arm in `handle_event_msg`, routing hook events to `finalize_shell_hook`.
- **`entry.rs`**: Added 3 unit tests verifying v0.136.0 `shell_hook_output` entries parse as `event_msg` without error.

### TypeScript types (`shared/types.ts`)
- Added `"shell_hook"` to the `ToolKind` union so the frontend type stays in sync with the Rust enum.

### UI (`src/components/`, `src/styles/`)
- Added `HookIcon` component (using `VscBeaker` from `react-icons/vsc`).
- Wired `HookIcon` and `"tool-call--hook"` CSS class in `ToolCallItem` so shell hook events render as a visually distinct tool kind.
- Added `.tool-call--hook` colour rules in `global.css` using the existing `--icon-hook` CSS variable.

## Tests

10 new regression tests added:

- `toolcall.rs`: 3 unit tests for `finalize_shell_hook` (pre_exec success, post_exec failure, absent nullable fields)
- `turn.rs`: 4 integration tests for the full parse pipeline (pre_exec classified, post_exec failed status, absent nullable fields, all standard entry types regression guard)
- `entry.rs`: 3 entry-level tests (parses as event_msg, absent nullable fields, all standard types regression guard)

All 176 Rust tests and 128 frontend tests pass. Clippy `-D warnings` clean. `cargo fmt` clean.
