### PR TITLE
[#107]: expose subagent identity fields from Codex v0.134.0 hook inputs

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -67,6 +67,10 @@ export interface CodexToolCall {
   mcp_tool: string | null;
   /** Codex v0.133.0+: identifies which plugin the MCP tool belongs to. Null for pre-v0.133.0 sessions. */
   plugin_id: string | null;
+  /** Codex v0.134.0+ (PR #22882): subagent session ID from hook input identity fields. Null for parent-agent calls and pre-v0.134.0 sessions. */
+  subagent_id: string | null;
+  /** Codex v0.134.0+ (PR #22882): subagent human-readable name from hook input identity fields. Null for parent-agent calls and pre-v0.134.0 sessions. */
+  subagent_name: string | null;
   patch_success: boolean | null;
   patch_changes: Record<string, { type: string; content?: string; unified_diff?: string }> | null;
   web_query: string | null;

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -669,6 +669,44 @@ mod tests {
         assert_eq!(mems[1], "Project uses TypeScript strict mode");
     }
 
+    // Codex v0.134.0 (PR #22882): subagent identity fields added to hook input payloads.
+    //
+    // PreToolUse and PostToolUse hook inputs now carry `subagent_id` and `subagent_name`
+    // so that tool calls can be attributed to the subagent that produced them in
+    // multi-agent sessions. These fields are additive — the loosely-typed RawEntry model
+    // ignores unknown fields by design, so no deserialization errors can occur regardless
+    // of whether the fields are present.
+
+    #[test]
+    fn v0134_exec_command_end_with_subagent_identity_parses_without_error() {
+        // exec_command_end event carrying the new subagent_id / subagent_name fields
+        // (PostToolUse hook input, logged by Codex ≥ v0.134.0). The RawEntry parser
+        // must accept these fields without panic — they are ignored at this layer and
+        // consumed downstream in toolcall.rs.
+        let line = r#"{"timestamp":"2026-05-26T10:00:05Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_1","aggregated_output":"ok\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":50000000},"subagent_id":"worker-session-abc","subagent_name":"Parfit"}}"#;
+        let e = RawEntry::parse(line).expect("exec_command_end with subagent fields must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(
+            e.payload.get("type").and_then(|t| t.as_str()),
+            Some("exec_command_end")
+        );
+        // Subagent fields flow through to the payload Value for downstream extraction.
+        assert_eq!(e.payload["subagent_id"], "worker-session-abc");
+        assert_eq!(e.payload["subagent_name"], "Parfit");
+    }
+
+    #[test]
+    fn v0134_function_call_with_subagent_identity_parses_without_error() {
+        // function_call response_item carrying subagent_id / subagent_name (PreToolUse
+        // hook input). Must parse correctly so downstream toolcall.rs can extract the
+        // identity and store it on the resulting ToolCall.
+        let line = r#"{"timestamp":"2026-05-26T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hi\"}","call_id":"call_sub","subagent_id":"worker-session-xyz","subagent_name":"Noether"}}"#;
+        let e = RawEntry::parse(line).expect("function_call with subagent fields must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["subagent_id"], "worker-session-xyz");
+        assert_eq!(e.payload["subagent_name"], "Noether");
+    }
+
     #[test]
     fn v0135_all_standard_entry_types_parse_correctly() {
         // Regression guard: all four standard JSONL entry types from a v0.135.0 session

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -983,6 +983,79 @@ mod tests {
         assert!(!session.is_ongoing);
     }
 
+    // Codex v0.134.0 (PR #22882): subagent identity fields added to hook input payloads.
+    //
+    // Tool call end events now optionally carry `subagent_id` and `subagent_name`.
+    // The full parse pipeline must propagate these fields from the JSONL events through
+    // to the ToolCall structs returned in CodexSession.turns[].tool_calls[].
+
+    #[test]
+    fn v0134_parse_session_with_subagent_identity_in_exec_command_end() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-26T10-00-00-v0134sub.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-26T10:00:00Z","type":"session_meta","payload":{"id":"v0134-sub-session","timestamp":"2026-05-26T10:00:00Z","cwd":"/tmp","cli_version":"0.134.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-26T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-26T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hello\",\"workdir\":\"/tmp\"}","call_id":"call_sub_1","subagent_id":"worker-sess-abc","subagent_name":"Parfit"}}"#,
+                r#"{"timestamp":"2026-05-26T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_sub_1","aggregated_output":"hello\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":50000000},"subagent_id":"worker-sess-abc","subagent_name":"Parfit"}}"#,
+                r#"{"timestamp":"2026-05-26T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748253604.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0134-sub-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.134.0"));
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(session.turns[0].tool_calls.len(), 1);
+        let tool = &session.turns[0].tool_calls[0];
+        assert_eq!(tool.name, "exec_command");
+        assert_eq!(tool.subagent_id.as_deref(), Some("worker-sess-abc"));
+        assert_eq!(tool.subagent_name.as_deref(), Some("Parfit"));
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn v0134_parse_session_without_subagent_identity_fields_is_unaffected() {
+        // Pre-v0.134.0 sessions and parent-agent tool calls must parse normally
+        // with subagent_id/subagent_name defaulting to None on every ToolCall.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-26T10-01-00-v0134nosub.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-26T10:01:00Z","type":"session_meta","payload":{"id":"v0134-no-sub","timestamp":"2026-05-26T10:01:00Z","cwd":"/tmp","cli_version":"0.134.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-26T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-26T10:01:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/tmp\"}","call_id":"call_plain"}}"#,
+                r#"{"timestamp":"2026-05-26T10:01:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_plain","aggregated_output":"file.txt\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":5000000}}}"#,
+                r#"{"timestamp":"2026-05-26T10:01:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748253664.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0134-no-sub");
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(session.turns[0].tool_calls.len(), 1);
+        let tool = &session.turns[0].tool_calls[0];
+        assert!(
+            tool.subagent_id.is_none(),
+            "subagent_id must be None for parent-agent calls"
+        );
+        assert!(
+            tool.subagent_name.is_none(),
+            "subagent_name must be None for parent-agent calls"
+        );
+    }
+
     #[test]
     fn v0135_session_without_memories_produces_empty_vec() {
         // Pre-v0.135.0 sessions must parse normally with an empty memories Vec.

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -42,6 +42,12 @@ pub struct ToolCall {
     pub image_prompt: Option<String>,
     pub worker_session: Option<Box<super::session::CodexSession>>,
     pub status: String,
+    /// Codex v0.134.0 (PR #22882): subagent session ID from hook input identity fields.
+    /// Null for parent-agent tool calls and sessions from pre-v0.134.0.
+    pub subagent_id: Option<String>,
+    /// Codex v0.134.0 (PR #22882): subagent human-readable name from hook input identity fields.
+    /// Null for parent-agent tool calls and sessions from pre-v0.134.0.
+    pub subagent_name: Option<String>,
 }
 
 /// A pending (not yet finalized) tool call — waiting for its end event.
@@ -149,6 +155,8 @@ impl ToolCallBuilder {
                 } else {
                     "failed".to_string()
                 },
+                subagent_id: None,
+                subagent_name: None,
             });
         }
     }
@@ -236,6 +244,8 @@ impl ToolCallBuilder {
                     image_prompt: None,
                     worker_session: None,
                     status: spawn_agent_status(output),
+                    subagent_id: None,
+                    subagent_name: None,
                 });
                 return;
             }
@@ -284,6 +294,8 @@ impl ToolCallBuilder {
                 image_prompt: None,
                 worker_session: None,
                 status: "completed".to_string(),
+                subagent_id: None,
+                subagent_name: None,
             });
         }
     }
@@ -356,6 +368,7 @@ impl ToolCallBuilder {
         });
         let status = str_field(payload, "status");
 
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
         self.finalized.push(ToolCall {
             call_id,
             kind: ToolKind::ExecCommand,
@@ -377,6 +390,8 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status,
+            subagent_id,
+            subagent_name,
         });
     }
 
@@ -417,6 +432,7 @@ impl ToolCallBuilder {
         let output = extract_mcp_output(payload);
         let duration_secs = parse_duration(payload);
         let plugin_id = pending.plugin_id;
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
 
         self.finalized.push(ToolCall {
             call_id,
@@ -439,6 +455,8 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: "completed".to_string(),
+            subagent_id,
+            subagent_name,
         });
     }
 
@@ -502,6 +520,7 @@ impl ToolCallBuilder {
                 plugin_id: None,
             });
 
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
         self.finalized.push(ToolCall {
             call_id,
             kind: ToolKind::PatchApply,
@@ -523,13 +542,17 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: str_field(payload, "status"),
+            subagent_id,
+            subagent_name,
         });
     }
 
     /// Finalize with collab_agent_spawn_end event.
     pub fn finalize_spawn(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
-        let pending_name = self.pending.remove(&call_id).map(|p| p.name);
+        let pending = self.pending.remove(&call_id);
+        let pending_name = pending.as_ref().map(|p| p.name.clone());
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
 
         self.finalized.push(ToolCall {
             call_id,
@@ -552,13 +575,17 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: str_field(payload, "status"),
+            subagent_id,
+            subagent_name,
         });
     }
 
     /// Finalize with collab_waiting_end event.
     pub fn finalize_wait(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
-        let pending_name = self.pending.remove(&call_id).map(|p| p.name);
+        let pending = self.pending.remove(&call_id);
+        let pending_name = pending.as_ref().map(|p| p.name.clone());
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
 
         self.finalized.push(ToolCall {
             call_id,
@@ -581,13 +608,17 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: "completed".to_string(),
+            subagent_id,
+            subagent_name,
         });
     }
 
     /// Finalize with collab_close_end event.
     pub fn finalize_close(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
-        let pending_name = self.pending.remove(&call_id).map(|p| p.name);
+        let pending = self.pending.remove(&call_id);
+        let pending_name = pending.as_ref().map(|p| p.name.clone());
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
 
         self.finalized.push(ToolCall {
             call_id,
@@ -610,13 +641,16 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: "completed".to_string(),
+            subagent_id,
+            subagent_name,
         });
     }
 
     /// Finalize web_search (no call_id pairing — best-effort).
     pub fn add_web_search(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
-        let pending_name = self.pending.remove(&call_id).map(|p| p.name);
+        let pending = self.pending.remove(&call_id);
+        let pending_name = pending.as_ref().map(|p| p.name.clone());
         let query = payload
             .get("query")
             .and_then(|v| v.as_str())
@@ -626,6 +660,7 @@ impl ToolCallBuilder {
             .and_then(|a| a.get("url"))
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
 
         self.finalized.push(ToolCall {
             call_id,
@@ -648,6 +683,8 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: "completed".to_string(),
+            subagent_id,
+            subagent_name,
         });
     }
 
@@ -674,6 +711,7 @@ impl ToolCallBuilder {
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string())
             });
+        let (subagent_id, subagent_name) = extract_subagent_identity(payload);
         self.finalized.push(ToolCall {
             call_id,
             kind: ToolKind::Unknown,
@@ -695,6 +733,8 @@ impl ToolCallBuilder {
             image_prompt: None,
             worker_session: None,
             status: str_field(payload, "status"),
+            subagent_id,
+            subagent_name,
         });
     }
 
@@ -723,6 +763,8 @@ impl ToolCallBuilder {
                 image_prompt: None,
                 worker_session: None,
                 status: "unknown".to_string(),
+                subagent_id: None,
+                subagent_name: None,
             });
         }
         // Remove Unknown entries that share a call_id with a properly classified end-event entry.
@@ -777,6 +819,8 @@ fn exec_tool_call_from_pending(
         image_prompt: None,
         worker_session: None,
         status: parsed_output.status,
+        subagent_id: None,
+        subagent_name: None,
     }
 }
 
@@ -966,6 +1010,25 @@ fn push_unique(values: &mut Vec<String>, value: String) {
     }
 }
 
+/// Extract subagent identity from a tool-call end-event payload.
+///
+/// Added in Codex v0.134.0 (PR #22882): `subagent_id` and `subagent_name` are now
+/// injected into PostToolUse hook input payloads and logged as part of tool call end
+/// events, enabling per-tool multi-agent attribution in the parent session's JSONL.
+fn extract_subagent_identity(payload: &Value) -> (Option<String>, Option<String>) {
+    let id = payload
+        .get("subagent_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let name = payload
+        .get("subagent_name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    (id, name)
+}
+
 /// Reconstruct MCP server + tool from the `namespace` field and function `name`.
 ///
 /// OpenAI encodes MCP tools as: namespace = `mcp__<server>__[ns_suffix]`, name = `[_suffix]`.
@@ -1100,7 +1163,7 @@ mod tests {
             r#"{"cmd":"echo hello","workdir":"/tmp"}"#,
             None,
             None,
-            None,
+            None, // plugin_id
         );
 
         // v0.132.0 exec_command_end: only aggregated_output, no formatted_output
@@ -1148,6 +1211,124 @@ mod tests {
         assert!(
             !old_out.contains("research preview"),
             "banner text leaked into output"
+        );
+    }
+
+    // Codex v0.134.0 (PR #22882): subagent identity fields added to hook input payloads.
+    // exec_command_end, mcp_tool_call_end, and other end events now optionally carry
+    // `subagent_id` and `subagent_name` so that tool calls can be attributed to the
+    // subagent that executed them in multi-agent sessions.
+    //
+    // The parser must:
+    //   1. Expose the fields on ToolCall when present in the end event payload.
+    //   2. Propagate them from function_call (PendingCall) when present there instead.
+    //   3. Default both to None for pre-v0.134.0 sessions and parent-agent tool calls.
+
+    #[test]
+    fn v0134_exec_command_end_with_subagent_identity_populates_tool_call() {
+        use super::super::super::parser::toolcall::ToolCallBuilder;
+        use serde_json::json;
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_exec_sub".to_string(),
+            "exec_command".to_string(),
+            r#"{"cmd":"echo subagent","workdir":"/tmp"}"#,
+            None,
+            None,
+            None, // plugin_id
+        );
+
+        // v0.134.0 exec_command_end: carries subagent identity
+        let payload = json!({
+            "call_id": "call_exec_sub",
+            "aggregated_output": "subagent\n",
+            "exit_code": 0,
+            "status": "completed",
+            "duration": {"secs": 0, "nanos": 10_000_000u64},
+            "subagent_id": "worker-session-abc",
+            "subagent_name": "Parfit"
+        });
+        builder.finalize_exec("exec_command_end", &payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.output.as_deref(), Some("subagent\n"));
+        assert_eq!(tool.exit_code, Some(0));
+        assert_eq!(tool.subagent_id.as_deref(), Some("worker-session-abc"));
+        assert_eq!(tool.subagent_name.as_deref(), Some("Parfit"));
+    }
+
+    #[test]
+    fn v0134_mcp_tool_call_end_with_subagent_identity_populates_tool_call() {
+        // Codex v0.134.0 (PR #22882): subagent_id/subagent_name are present on PostToolUse
+        // hook input data, which is included in mcp_tool_call_end event payloads. The parser
+        // must extract these fields from the end event and populate ToolCall accordingly.
+        use super::super::super::parser::toolcall::ToolCallBuilder;
+        use serde_json::json;
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_mcp_sub".to_string(),
+            "get_pr".to_string(),
+            r#"{}"#,
+            Some("mcp__github".to_string()),
+            None,
+            None, // plugin_id
+        );
+
+        // mcp_tool_call_end carries subagent identity in PostToolUse hook data
+        let payload = json!({
+            "call_id": "call_mcp_sub",
+            "result": {"Ok": {"content": [{"type": "text", "text": "PR info"}]}},
+            "subagent_id": "worker-session-xyz",
+            "subagent_name": "Noether"
+        });
+        builder.finalize_mcp("mcp_tool_call_end", &payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.subagent_id.as_deref(), Some("worker-session-xyz"));
+        assert_eq!(tool.subagent_name.as_deref(), Some("Noether"));
+        assert_eq!(tool.output.as_deref(), Some("PR info"));
+    }
+
+    #[test]
+    fn v0134_absent_subagent_fields_default_to_none() {
+        // Pre-v0.134.0 sessions and parent-agent tool calls must have None for both
+        // subagent fields — existing logic must be backward-compatible.
+        use super::super::super::parser::toolcall::ToolCallBuilder;
+        use serde_json::json;
+
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_no_sub".to_string(),
+            "exec_command".to_string(),
+            r#"{"cmd":"ls","workdir":"/tmp"}"#,
+            None,
+            None,
+            None, // plugin_id
+        );
+
+        let payload = json!({
+            "call_id": "call_no_sub",
+            "aggregated_output": "file.txt\n",
+            "exit_code": 0,
+            "status": "completed",
+            "duration": {"secs": 0, "nanos": 5_000_000u64}
+        });
+        builder.finalize_exec("exec_command_end", &payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        // Both fields must be None for pre-v0.134.0 sessions.
+        assert!(
+            tool.subagent_id.is_none(),
+            "subagent_id must be None when absent"
+        );
+        assert!(
+            tool.subagent_name.is_none(),
+            "subagent_name must be None when absent"
         );
     }
 }

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -25,6 +25,8 @@ function makeTool(overrides: Partial<CodexToolCall> = {}): CodexToolCall {
     image_prompt: null,
     worker_session: null,
     status: "completed",
+    subagent_id: null,
+    subagent_name: null,
     ...overrides,
   };
 }

--- a/src/components/TurnList.test.tsx
+++ b/src/components/TurnList.test.tsx
@@ -41,6 +41,8 @@ const EXEC_TOOL: CodexToolCall = {
   image_prompt: null,
   worker_session: null,
   status: "completed",
+  subagent_id: null,
+  subagent_name: null,
 };
 
 function makeTurn(overrides: Partial<CodexTurn> = {}): CodexTurn {

--- a/src/components/WorkerPanel.test.tsx
+++ b/src/components/WorkerPanel.test.tsx
@@ -28,6 +28,8 @@ function makeTool(overrides: Partial<CodexToolCall> = {}): CodexToolCall {
     image_prompt: null,
     worker_session: null,
     status: "completed",
+    subagent_id: null,
+    subagent_name: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Codex v0.134.0 ([PR #22882](https://github.com/codex-dev/codex/pull/22882)) added `subagent_id` and `subagent_name` to PreToolUse/PostToolUse hook input payloads in multi-agent sessions, enabling per-tool attribution to the specific subagent (worker session) that executed each tool call.

This PR wires those fields through the codex-trace parsing pipeline so they are surfaced on every `ToolCall`/`CodexToolCall` object.

## Changes

### Rust backend (`src-tauri/src/parser/`)

- **`toolcall.rs`**: Added `subagent_id: Option<String>` and `subagent_name: Option<String>` to `ToolCall`. Added `extract_subagent_identity(payload)` helper that reads both fields from end-event payloads (`exec_command_end`, `mcp_tool_call_end`, `patch_apply_end`, `collab_*_end`, `web_search_end`). All finalize methods now call the helper and populate the new fields; pre-v0.134.0 sessions and parent-agent calls default to `None`.
- **`entry.rs`**: Two new parser-layer tests verifying `exec_command_end` and `function_call` entries with the new fields parse without error or panic.
- **`session.rs`**: Two integration tests verifying the full pipeline from JSONL input through to `ToolCall.subagent_id`/`subagent_name` on the parsed session — one for sessions with subagent identity, one backward-compat test for sessions without it.

### TypeScript (`shared/types.ts`)

- Added `subagent_id: string | null` and `subagent_name: string | null` to the `CodexToolCall` interface (null for parent-agent calls and pre-v0.134.0 sessions).
- Updated three test fixtures (`ToolCallItem.test.tsx`, `TurnList.test.tsx`, `WorkerPanel.test.tsx`) with the new required fields.

## Tests

- 173 Rust unit tests pass (3 new: `v0134_exec_command_end_with_subagent_identity_populates_tool_call`, `v0134_mcp_tool_call_end_with_subagent_identity_populates_tool_call`, `v0134_absent_subagent_fields_default_to_none`)
- 128 frontend tests pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- HTTP API smoke test: `POST /api/sessions` returns 200 with JSON

## Backward Compatibility

The change is purely additive. The JSONL parser uses `serde_json::Value` throughout, so JSONL files without `subagent_id`/`subagent_name` continue to parse correctly with both fields defaulting to `null`/`None`.

Fixes #107
