### PR TITLE
Inline assistant commentary + font sync; manual release path; CHANGELOG attribution

### DIFF
--- a/.claude/skills/cut-release/references/changelog-template.md
+++ b/.claude/skills/cut-release/references/changelog-template.md
@@ -25,13 +25,14 @@ maintainer — explain visible impact, not implementation.
 
 ### Added
 
-- **Headline name** ([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>)).
+- **Headline name** ([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>), @contributor).
   Two or three sentences. Why it exists, what the user sees, any caveat. End with a
-  pointer to verification or docs if useful.
+  pointer to verification or docs if useful. (Drop `@contributor` when the author is the
+  maintainer — see Attribution.)
 
 ### Fixed
 
-- **Headline name** ([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>)).
+- **Headline name** ([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>), @contributor).
   What was broken, when it surfaced, how it surfaces now. Avoid jargon-only entries like
   "fix race condition" — say which user-visible behavior was wrong and is now right.
 
@@ -73,6 +74,23 @@ Each bullet **must** link to its commit so readers can dig in:
 
 The reference-link at the bottom (`[X.Y.Z]: https://...releases/tag/...`) is what GitHub
 uses to make the version header a clickable link in rendered markdown. Keep it.
+
+## Attribution
+
+Credit external contributors. When a bullet's commit/PR was authored by **anyone other
+than the maintainer (`delexw`)**, append the author's GitHub handle to the commit link so
+the contribution is acknowledged:
+
+```
+([`ebb2ca5`](https://github.com/PixelPaw-Labs/codex-trace/commit/ebb2ca5), @contributor)
+```
+
+- Omit the handle entirely for the maintainer's own commits (`delexw`) — don't write
+  `@delexw`. The default authorship is the maintainer, so an unattributed bullet means
+  "by the maintainer".
+- One handle per bullet (the PR author). If a bullet summarizes several commits by the
+  same external author, attribute once.
+- Phase 4 explains how to resolve the handle from each commit/PR.
 
 ## Style
 

--- a/.claude/skills/cut-release/references/project-shape.md
+++ b/.claude/skills/cut-release/references/project-shape.md
@@ -63,8 +63,12 @@ pushes:
    each creating / updating a draft release with platform artifacts.
 4. `publish` — flips the draft to public and marks it latest.
 
-`workflow_dispatch` mode is a dry-run for the notes job only; nothing is built or
-published. Use it to verify a CHANGELOG section parses correctly before tagging.
+`workflow_dispatch` mode (manual run, with a `version` input) is the artifact-free
+path: the `manual-release` job runs `notes` then creates the `vX.Y.Z` tag and a
+published, latest GitHub release whose body is the CHANGELOG section — but it builds
+**no** desktop binaries. It refuses to overwrite an existing release for the version.
+Use it to bootstrap a release (e.g. the first tag) or to publish a notes-only release;
+use a `v*` tag push when you want the full macOS / Linux / Windows artifact build.
 
 If the pipeline changes, edit the workflow and update Phase 7's narrative, not this
 file.

--- a/.claude/skills/cut-release/steps/phase4-changelog.md
+++ b/.claude/skills/cut-release/steps/phase4-changelog.md
@@ -25,7 +25,26 @@ For each chosen commit in `$SUBSET`:
    - deletions of public surface → Removed
 2. Read the diff if the subject is terse — the bullet should explain user-visible impact,
    not summarize the commit message verbatim.
-3. End the bullet with a commit link: ``([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>))``
+3. Resolve the author handle for attribution (see `changelog-template.md` → Attribution).
+   When the commit subject carries a squashed PR number `(#NN)`:
+
+   ```bash
+   gh pr view <NN> --repo "$(git remote get-url origin)" --json author --jq '.author.login'
+   ```
+
+   Otherwise fall back to the commit's GitHub author:
+
+   ```bash
+   gh api "repos/{owner}/{repo}/commits/<sha>" --jq '.author.login'
+   ```
+
+   If the login is **not** `delexw` (the maintainer), the bullet must credit them; if it
+   **is** `delexw`, add no handle.
+
+4. End the bullet with a commit link, plus the handle when the author isn't the
+   maintainer:
+   - external author: ``([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>), @contributor)``
+   - maintainer (`delexw`): ``([`<sha7>`](https://github.com/PixelPaw-Labs/codex-trace/commit/<sha>))``
 
 Always skip `chore:` / `docs:` / `test:` / `ci:` — they clutter user-facing CHANGELOGs.
 The skill is non-interactive.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to dry-run, e.g. 0.1.0 (no v prefix). Only the notes job runs; nothing is built or published."
+        description: "Version to release, e.g. 0.1.0 (no v prefix). Creates the tag and a published GitHub release from the matching CHANGELOG section. No desktop artifacts are built — use a v* tag push for a full multi-platform build."
         required: true
         type: string
 
@@ -226,3 +226,39 @@ jobs:
             --repo "${{ github.repository }}" \
             --draft=false \
             --latest
+
+  manual-release:
+    name: Create release without artifacts (manual)
+    needs: notes
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Create published release (tag + notes, no build artifacts)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.notes.outputs.version }}
+          BODY: ${{ needs.notes.outputs.body }}
+        run: |
+          set -euo pipefail
+          TAG="v$VERSION"
+          # Refuse to clobber an existing release/tag — the manual path is for
+          # bootstrapping a version that hasn't shipped yet. To re-release,
+          # delete the existing one first: gh release delete $TAG --yes --cleanup-tag
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error title=Duplicate release::A release for $TAG already exists. Refusing to overwrite."
+            exit 1
+          fi
+          printf '%s\n' "$BODY" > "$RUNNER_TEMP/notes.md"
+          # Creates the tag at this commit (the dispatched ref) and a published,
+          # latest release with the CHANGELOG section as the body. No artifacts.
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
+            --latest
+          echo "Created release $TAG at $GITHUB_SHA with no build artifacts."

--- a/src/components/ComplementaryItem.test.tsx
+++ b/src/components/ComplementaryItem.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../../shared/types";
+import { ComplementaryItem } from "./ComplementaryItem";
+
+function makeMsg(overrides: Partial<AgentMessage> = {}): AgentMessage {
+  return {
+    text: "INLINE_PROSE",
+    phase: "commentary",
+    timestamp: "2026-04-26T10:00:00Z",
+    is_reasoning: false,
+    order: 0,
+    ...overrides,
+  };
+}
+
+describe("ComplementaryItem", () => {
+  it("shows the assistant prose inline by default with no interaction", () => {
+    render(<ComplementaryItem msg={makeMsg()} />);
+    // Prose is visible immediately — never gated behind an expand/collapse chevron.
+    expect(screen.getByText("INLINE_PROSE")).toBeInTheDocument();
+    expect(screen.getByText("Complementary")).toBeInTheDocument();
+    expect(document.querySelector(".complementary-item__chevron")).toBeNull();
+  });
+
+  it("renders markdown in the prose", () => {
+    const { container } = render(<ComplementaryItem msg={makeMsg({ text: "**bold words**" })} />);
+    expect(container.querySelector("strong")).toHaveTextContent("bold words");
+  });
+
+  it("omits the timestamp when none is present", () => {
+    render(<ComplementaryItem msg={makeMsg({ timestamp: "" })} />);
+    expect(document.querySelector(".complementary-item__time")).toBeNull();
+  });
+});

--- a/src/components/ComplementaryItem.tsx
+++ b/src/components/ComplementaryItem.tsx
@@ -1,0 +1,33 @@
+import type { AgentMessage } from "../../shared/types";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+import { OutputIcon } from "./Icons";
+import { formatExactTime } from "../lib/format";
+
+interface ComplementaryItemProps {
+  msg: AgentMessage;
+}
+
+// The assistant's commentary rendered as a first-class timeline item. Its prose is shown
+// inline and always (never gated behind an expand/collapse chevron), so a turn reads as
+// commentary -> tool call -> commentary -> ... -> final answer in chronological order,
+// instead of the text being a flattened blob or hidden behind a click.
+export function ComplementaryItem({ msg }: ComplementaryItemProps) {
+  return (
+    <div className="complementary-item">
+      <div className="complementary-item__header">
+        <span className="complementary-item__icon">
+          <OutputIcon />
+        </span>
+        <span className="complementary-item__name">Complementary</span>
+        {msg.timestamp && (
+          <span className="complementary-item__time">{formatExactTime(msg.timestamp)}</span>
+        )}
+      </div>
+      <div className="complementary-item__body">
+        <div className="turn-detail__markdown">
+          <MarkdownRenderer content={msg.text} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -16,6 +16,7 @@ import {
   VscLinkExternal,
   VscClose,
   VscBeaker,
+  VscComment,
 } from "react-icons/vsc";
 import { MdOutlineGeneratingTokens, MdOutlineImage } from "react-icons/md";
 import { GoGitMerge } from "react-icons/go";
@@ -104,6 +105,10 @@ export function DurationIcon() {
 
 export function ThinkingIcon() {
   return <VscLightbulbEmpty className="icon--thinking" />;
+}
+
+export function OutputIcon() {
+  return <VscComment className="icon--output" />;
 }
 
 export function PopoutIcon() {

--- a/src/components/TurnDetail.test.tsx
+++ b/src/components/TurnDetail.test.tsx
@@ -101,6 +101,31 @@ describe("TurnDetail", () => {
     expect(screen.getByText("40.0k tok · 1m")).toBeInTheDocument();
   });
 
+  it("renders assistant commentary as an inline Complementary item without duplication", () => {
+    const msg: AgentMessage = {
+      text: "COMMENTARY_TEXT",
+      phase: "commentary",
+      timestamp: "2026-04-26T10:00:00Z",
+      is_reasoning: false,
+      order: 0,
+    };
+    const { container } = render(
+      <TurnDetail
+        turn={makeTurn({ agent_messages: [msg], tool_calls: [], final_answer: null })}
+        expanded={new Set()}
+        onToggle={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    // Shown as a labelled Complementary item with its prose inline (no expansion needed)...
+    expect(screen.getByText("Complementary")).toBeInTheDocument();
+    expect(screen.getByText("COMMENTARY_TEXT")).toBeInTheDocument();
+    // ...and exactly once — no duplicated flattened blob above the timeline.
+    const occurrences = (container.textContent ?? "").split("COMMENTARY_TEXT").length - 1;
+    expect(occurrences).toBe(1);
+  });
+
   it("interleaves tool calls with commentary by stream order", () => {
     const first: AgentMessage = {
       text: "FIRST_MESSAGE",

--- a/src/components/TurnDetail.tsx
+++ b/src/components/TurnDetail.tsx
@@ -1,5 +1,6 @@
 import type { AgentMessage, CodexToolCall, CodexTurn } from "../../shared/types";
 import { ToolCallItem } from "./ToolCallItem";
+import { ComplementaryItem } from "./ComplementaryItem";
 import { OngoingDots } from "./OngoingDots";
 import { BackIcon, CodexIcon } from "./Icons";
 import { MarkdownRenderer } from "./MarkdownRenderer";
@@ -127,18 +128,7 @@ export function TurnDetail({
             <div className="turn-detail__section turn-detail__section--activity">
               {timeline.map((item, i) =>
                 item.kind === "msg" ? (
-                  <div key={`m-${item.msg.timestamp || i}`} className="turn-detail__msg">
-                    {item.msg.timestamp && (
-                      <div className="turn-detail__msg-header">
-                        <span className="turn-detail__msg-time">
-                          {formatExactTime(item.msg.timestamp)}
-                        </span>
-                      </div>
-                    )}
-                    <div className="turn-detail__markdown">
-                      <MarkdownRenderer content={item.msg.text} />
-                    </div>
-                  </div>
+                  <ComplementaryItem key={`m-${item.msg.timestamp || i}`} msg={item.msg} />
                 ) : (
                   <ToolCallItem
                     key={`t-${item.tool.call_id || item.index}`}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2449,7 +2449,7 @@ body {
   min-width: 0;
 }
 .sidebar-tree__session-label {
-  font-size: 13px;
+  font-size: 12px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3006,7 +3006,8 @@ body {
   border-color: var(--status-error);
 }
 .tool-call__name {
-  font-size: 14px;
+  font-size: 12px;
+  font-weight: 600;
   color: var(--text-bright);
   white-space: nowrap;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2338,7 +2338,7 @@ body {
   flex-shrink: 0;
 }
 .app__sidebar-title {
-  font-size: 0.72rem;
+  font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--text-dim);
@@ -2349,7 +2349,7 @@ body {
   border: none;
   cursor: pointer;
   color: var(--text-dim);
-  font-size: 1rem;
+  font-size: 16px;
   padding: 2px 4px;
 }
 .app__settings-btn:hover {
@@ -2396,7 +2396,7 @@ body {
 }
 .sidebar-tree__empty {
   color: var(--text-dim);
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 .sidebar-tree__group {
   margin-bottom: 2px;
@@ -2409,7 +2409,7 @@ body {
   cursor: pointer;
   user-select: none;
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 600;
 }
 .sidebar-tree__date-header:hover {
@@ -2417,7 +2417,7 @@ body {
   color: var(--text-bright);
 }
 .sidebar-tree__chevron {
-  font-size: 0.6rem;
+  font-size: 10px;
 }
 .sidebar-tree__date {
   flex: 1;
@@ -2426,7 +2426,7 @@ body {
   background: var(--bg-hover);
   border-radius: 8px;
   padding: 0 5px;
-  font-size: 0.7rem;
+  font-size: 11px;
 }
 .sidebar-tree__session {
   display: flex;
@@ -2449,7 +2449,7 @@ body {
   min-width: 0;
 }
 .sidebar-tree__session-label {
-  font-size: 0.8rem;
+  font-size: 13px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2467,13 +2467,13 @@ body {
   margin-top: 2px;
 }
 .sidebar-tree__time {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--text-dim);
   white-space: nowrap;
   flex-shrink: 0;
 }
 .sidebar-tree__badge {
-  font-size: 0.65rem;
+  font-size: 10px;
   padding: 0 4px;
   border-radius: 4px;
 }
@@ -2495,7 +2495,7 @@ body {
   border: none;
   padding: 0;
   cursor: pointer;
-  font-size: 0.65rem;
+  font-size: 10px;
   color: var(--collab-badge);
   display: flex;
   align-items: center;
@@ -2509,7 +2509,7 @@ body {
   opacity: 0.85;
 }
 .sidebar-tree__session--child .sidebar-tree__session-label {
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 
 /* Session picker */
@@ -2755,7 +2755,7 @@ body {
   min-width: 0;
 }
 .turn-list__row-status {
-  font-size: 0.8rem;
+  font-size: 13px;
   flex-shrink: 0;
 }
 .turn-list__row-status--complete {
@@ -2768,12 +2768,12 @@ body {
   color: var(--status-error);
 }
 .turn-list__row-duration {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--text-dim);
   flex-shrink: 0;
 }
 .turn-list__row-tools {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--icon-mcp);
   flex-shrink: 0;
 }
@@ -2813,7 +2813,7 @@ body {
   border-left: 3px solid var(--accent);
 }
 .turn-list__badge {
-  font-size: 0.65rem;
+  font-size: 10px;
   padding: 0 4px;
   border-radius: 3px;
 }
@@ -2858,23 +2858,23 @@ body {
   border-bottom: 1px solid var(--border);
 }
 .turn-detail__status {
-  font-size: 0.85rem;
+  font-size: 14px;
   text-transform: uppercase;
   color: var(--text-dim);
 }
 .turn-detail__model {
-  font-size: 0.8rem;
+  font-size: 13px;
   color: var(--accent);
 }
 .turn-detail__effort {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--text-dim);
 }
 .turn-detail__section {
   margin-bottom: 1.2rem;
 }
 .turn-detail__section-label {
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;
   color: var(--text-dim);
@@ -2888,7 +2888,7 @@ body {
   white-space: pre-wrap;
   word-break: break-word;
   font-family: inherit;
-  font-size: 0.875rem;
+  font-size: 14px;
   margin: 0;
   line-height: 1.5;
 }
@@ -2901,10 +2901,10 @@ body {
 .turn-detail__reasoning-note {
   color: var(--reasoning-text);
   font-style: italic;
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 .turn-detail__compaction-note {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--text-dim);
   font-style: italic;
   margin-top: 1rem;
@@ -2925,10 +2925,10 @@ body {
 .turn-detail__collab-nick {
   font-weight: 600;
   color: var(--collab-badge);
-  font-size: 0.85rem;
+  font-size: 14px;
 }
 .turn-detail__collab-model {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--text-dim);
 }
 .turn-detail__collab-btn {
@@ -2937,7 +2937,7 @@ body {
   border: 1px solid var(--collab-badge, #5f87d7);
   border-radius: 3px;
   color: var(--collab-badge, #5f87d7);
-  font-size: 0.75rem;
+  font-size: 12px;
   padding: 1px 6px;
   cursor: pointer;
   font-family: inherit;
@@ -2947,7 +2947,7 @@ body {
 }
 .turn-detail__collab-prompt {
   white-space: pre-wrap;
-  font-size: 0.8rem;
+  font-size: 13px;
   color: var(--text-dim);
   margin: 4px 0 0;
   border-top: 1px solid rgba(95, 135, 215, 0.2);
@@ -2974,7 +2974,7 @@ body {
   background: var(--bg-hover);
 }
 .tool-call__kind {
-  font-size: 0.7rem;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   padding: 1px 5px;
@@ -3006,7 +3006,7 @@ body {
   border-color: var(--status-error);
 }
 .tool-call__name {
-  font-size: 0.85rem;
+  font-size: 14px;
   color: var(--text-bright);
   white-space: nowrap;
 }
@@ -3016,25 +3016,25 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.78rem;
+  font-size: 12px;
   color: var(--text-dim);
 }
 .tool-call__mcp-prefix {
   color: var(--text-dim);
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 .tool-call__exit {
-  font-size: 0.75rem;
+  font-size: 12px;
 }
 .tool-call__exit--fail {
   color: var(--status-error);
 }
 .tool-call__duration {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--text-dim);
 }
 .tool-call__chevron {
-  font-size: 0.65rem;
+  font-size: 10px;
   color: var(--text-dim);
 }
 .tool-call__body {
@@ -3050,18 +3050,18 @@ body {
 .tool-call__cmd {
   white-space: pre-wrap;
   word-break: break-all;
-  font-size: 0.8rem;
+  font-size: 13px;
   margin: 0 0 6px;
 }
 .tool-call__cwd {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--text-dim);
   margin-bottom: 4px;
 }
 .tool-call__output {
   white-space: pre-wrap;
   word-break: break-word;
-  font-size: 0.8rem;
+  font-size: 13px;
   max-height: 300px;
   overflow-y: auto;
   margin: 6px 0 0;
@@ -3071,7 +3071,7 @@ body {
   color: var(--error);
 }
 .tool-call__diff {
-  font-size: 0.75rem;
+  font-size: 12px;
   white-space: pre;
   overflow-x: auto;
   overflow-y: auto;
@@ -3083,7 +3083,7 @@ body {
   border: 1px solid var(--collab-badge);
   color: var(--collab-badge);
   cursor: pointer;
-  font-size: 0.7rem;
+  font-size: 11px;
   padding: 1px 6px;
   border-radius: 3px;
   line-height: 1.4;
@@ -3224,7 +3224,7 @@ body {
 .tool-call__icon {
   display: inline-flex;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: 14px;
   flex-shrink: 0;
 }
 .tool-call--exec .tool-call__icon {
@@ -3255,7 +3255,7 @@ body {
   margin-bottom: 0;
 }
 .tool-call__section-title {
-  font-size: 0.7rem;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -3277,20 +3277,20 @@ body {
   margin: 0;
 }
 .tool-call__json code {
-  font-size: 0.8rem;
+  font-size: 13px;
   white-space: pre;
 }
 .tool-call__mcp-server {
   font-weight: 600;
   color: var(--icon-mcp);
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 .tool-call__mcp-tool {
-  font-size: 0.8rem;
+  font-size: 13px;
   color: var(--text-secondary);
 }
 .tool-call__web-url {
-  font-size: 0.75rem;
+  font-size: 12px;
   color: var(--text-dim);
   word-break: break-all;
   margin-top: 2px;
@@ -3314,7 +3314,7 @@ body {
 
 /* Turn detail markdown */
 .turn-detail__markdown {
-  font-size: 0.85rem;
+  font-size: 13px;
   line-height: 1.6;
   color: var(--text-primary);
   word-break: break-word;
@@ -3404,12 +3404,12 @@ body {
 .token-bar__stats {
   display: flex;
   gap: 8px;
-  font-size: 0.7rem;
+  font-size: 11px;
 }
 
 /* ToolCallItem body sub-elements */
 .tool-call__mcp-info {
-  font-size: 0.8rem;
+  font-size: 13px;
   margin-bottom: 4px;
 }
 .tool-call__patch {
@@ -3418,22 +3418,22 @@ body {
   gap: 6px;
 }
 .tool-call__patch-file {
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 .tool-call__web {
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 .tool-call__image-prompt {
-  font-size: 0.8rem;
+  font-size: 13px;
   font-style: italic;
 }
 .tool-call__collab-info {
-  font-size: 0.8rem;
+  font-size: 13px;
 }
 
 /* Tool call argument display */
 .tool-call__args {
-  font-size: 0.75rem;
+  font-size: 12px;
   white-space: pre-wrap;
   word-break: break-word;
   margin: 4px 0 0;
@@ -3463,7 +3463,7 @@ body {
 }
 .codex-worker-panel__turn-label,
 .codex-worker-panel__label {
-  font-size: 0.7rem;
+  font-size: 11px;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -3477,4 +3477,31 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+/* Complementary item — assistant commentary as an inline, always-expanded timeline item */
+.complementary-item {
+  margin-bottom: 10px;
+}
+.complementary-item__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+.complementary-item__icon {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  color: var(--icon-output);
+}
+.complementary-item__name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--icon-output);
+}
+.complementary-item__time {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-left: auto;
 }


### PR DESCRIPTION
Three related-to-tooling/UI changes that stacked on this branch.

## 1. Render assistant commentary inline + sync fonts (`3e7a52c`)
- New `ComplementaryItem` component: the assistant's commentary renders as a first-class timeline item (icon + **Complementary** label + timestamp) with its prose shown **inline and always** — never gated behind an expand/collapse chevron. `TurnDetail` renders it in the existing chronological stream (PR #100), so a turn reads `commentary → tool call → … → final answer` top to bottom.
- codex-trace already interleaves commentary chronologically and has **no flattened blob** above the timeline (the duplication claude-code-trace had to suppress), so there was nothing to suppress here.
- The backend already emits commentary as ordered items (`AgentMessage.order`/`timestamp`/`phase`) — **UI-only**, no Rust/types change.
- **Font sync to claude-code-trace:** the font-family already matched; codex used `rem` font-sizes (which scale with root/zoom) where claude uses fixed `px`. Converted all 53 `rem` font-sizes → `px` and set detail-view prose to **13px** to match claude's message body. Added `OutputIcon`.
- Tests: `ComplementaryItem.test.tsx` + a `TurnDetail` inline/no-duplication test. Full suite **135/135** green; tsc, oxlint, oxfmt clean.

## 2. Manual artifact-free release path (`02b26a4`)
- Adds a `manual-release` job to `release.yml`, gated on `workflow_dispatch`: it runs `notes` then creates the `vX.Y.Z` tag + a published, latest GitHub release from the CHANGELOG section, **building no desktop artifacts**. Refuses to overwrite an existing release. A `v*` tag push still runs the full guard → notes → macOS/Linux/Windows build → publish flow.

## 3. CHANGELOG author attribution (`d89da4e`)
- Updates the `cut-release` skill so generated CHANGELOG bullets append the PR/commit author's handle (e.g. `@contributor`) when the author isn't the maintainer (`delexw`); maintainer bullets stay unattributed. Adds the rule to `changelog-template.md` and an author-resolution step to `phase4-changelog.md`.

> Note: these are independent changes that shared one branch because the session can only push here.

https://claude.ai/code/session_01FLcTQTp5efCHTgWrpbYf64

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLcTQTp5efCHTgWrpbYf64)_