### PR TITLE
[#120]: Codex v0.139.0 compat — rename close_agent to interrupt_agent

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -54,7 +54,8 @@ export type ToolKind =
   | "image_generation"
   | "spawn_agent"
   | "wait_agent"
-  | "close_agent"
+  /** Codex < v0.139.0 used `close_agent`; renamed to `interrupt_agent` in v0.139.0 (PR #26994). */
+  | "interrupt_agent"
   /** multi-agent v2: assign_task (Codex < v0.136.0) or followup_task (≥ v0.136.0) */
   | "followup_task"
   /** Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks. */

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -14,7 +14,9 @@ pub enum ToolKind {
     ImageGeneration,
     SpawnAgent,
     WaitAgent,
-    CloseAgent,
+    /// Codex < v0.139.0 used `close_agent`; renamed to `interrupt_agent` in v0.139.0 (PR #26994).
+    /// Both old transcripts (close_agent) and new (interrupt_agent) map to this variant.
+    InterruptAgent,
     /// multi-agent v2 task assignment: `assign_task` (Codex < v0.136.0) or `followup_task` (≥ v0.136.0)
     FollowupTask,
     /// Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks.
@@ -341,7 +343,11 @@ impl ToolCallBuilder {
                         (ToolKind::McpTool, server, tool)
                     }
                     _ if pending.name == "wait_agent" => (ToolKind::WaitAgent, None, None),
-                    _ if pending.name == "close_agent" => (ToolKind::CloseAgent, None, None),
+                    // close_agent (Codex < v0.139.0) was renamed to interrupt_agent (≥ v0.139.0, PR #26994).
+                    // Accept both for backward compatibility with existing transcripts.
+                    _ if pending.name == "close_agent" || pending.name == "interrupt_agent" => {
+                        (ToolKind::InterruptAgent, None, None)
+                    }
                     _ => (ToolKind::Unknown, None, None),
                 }
             };
@@ -699,7 +705,7 @@ impl ToolCallBuilder {
 
         self.finalized.push(ToolCall {
             call_id,
-            kind: ToolKind::CloseAgent,
+            kind: ToolKind::InterruptAgent,
             name: pending_name.unwrap_or_else(|| kind_name(event_type)),
             arguments: payload.clone(),
             input_text: None,
@@ -1312,6 +1318,49 @@ mod tests {
             tool.duration_secs.is_some(),
             "duration should be extracted from structured field"
         );
+    }
+
+    // Codex v0.139.0 (PR #26994): multi-agent v2 close_agent renamed to interrupt_agent.
+    // Both old transcripts (close_agent) and new (interrupt_agent) must classify as InterruptAgent.
+
+    #[test]
+    fn close_agent_legacy_classified_as_interrupt_agent() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_close".to_string(),
+            "close_agent".to_string(),
+            r#"{"reason":"task complete"}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_close", r#"{"status":"ok"}"#);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::InterruptAgent);
+        assert_eq!(tool.name, "close_agent");
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn interrupt_agent_new_name_classified_as_interrupt_agent() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_interrupt".to_string(),
+            "interrupt_agent".to_string(),
+            r#"{"reason":"task complete"}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_interrupt", r#"{"status":"ok"}"#);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::InterruptAgent);
+        assert_eq!(tool.name, "interrupt_agent");
+        assert_eq!(tool.status, "completed");
     }
 
     // Codex v0.136.0 (PR #25267) renamed the multi-agent v2 assignment tool from

--- a/src/components/ToolCallItem.tsx
+++ b/src/components/ToolCallItem.tsx
@@ -44,7 +44,7 @@ function kindIcon(kind: CodexToolCall["kind"], failed: boolean) {
       return <SpawnIcon />;
     case "wait_agent":
       return <WaitIcon />;
-    case "close_agent":
+    case "interrupt_agent":
       return <CloseAgentIcon />;
     case "followup_task":
       return <FollowupTaskIcon />;
@@ -69,7 +69,7 @@ function kindClass(kind: CodexToolCall["kind"]): string {
       return "tool-call--image";
     case "spawn_agent":
     case "wait_agent":
-    case "close_agent":
+    case "interrupt_agent":
     case "followup_task":
       return "tool-call--collab";
     case "shell_hook":
@@ -295,7 +295,7 @@ function ToolCallBody({ tool, popout = false }: { tool: CodexToolCall; popout?: 
 
       {(tool.kind === "spawn_agent" ||
         tool.kind === "wait_agent" ||
-        tool.kind === "close_agent" ||
+        tool.kind === "interrupt_agent" ||
         tool.kind === "followup_task") &&
         Object.keys(tool.arguments ?? {}).length > 0 && (
           <div className="tool-call__section tool-call__section--input">


### PR DESCRIPTION
## Summary

Codex v0.139.0 (PR #26994) renamed the multi-agent v2 tool from `close_agent` to `interrupt_agent` in structured session output. Any codex-trace code matching `close_agent` would silently miss all such events going forward.

Fixes #120

## Changes

**`src-tauri/src/parser/toolcall.rs`**
- Renamed `ToolKind::CloseAgent` → `ToolKind::InterruptAgent` (serialises as `interrupt_agent` via `serde(rename_all = "snake_case")`)
- `add_function_call_output` now accepts **both** `close_agent` (Codex < v0.139.0) and `interrupt_agent` (≥ v0.139.0) and maps both to `ToolKind::InterruptAgent` for backward compatibility with existing transcripts
- `finalize_close` updated to emit `ToolKind::InterruptAgent`
- Added two new tests: `close_agent_legacy_classified_as_interrupt_agent` and `interrupt_agent_new_name_classified_as_interrupt_agent`

**`shared/types.ts`**
- Updated `ToolKind` union: `"close_agent"` → `"interrupt_agent"`

**`src/components/ToolCallItem.tsx`**
- Updated all three `"close_agent"` references (`kindIcon`, `kindClass`, body arguments condition) to `"interrupt_agent"`

## Migration path

Old transcripts that still contain `close_agent` function calls are handled transparently — they continue to display correctly as `InterruptAgent` without any user action.

## Test results

- 207 Rust unit tests: all pass
- 135 frontend (vitest) tests: all pass
- `cargo clippy -- -D warnings`: clean
- `npx oxlint` / `npx oxfmt` / `npx tsc --noEmit`: clean
- HTTP API smoke test: `GET /api/settings` returns 200 OK
