### PR TITLE
fix(parser): handle structured_output and message response_items for Codex v0.132.0

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -842,6 +842,50 @@ mod tests {
         assert!(e.payload.get("stderr").is_none());
     }
 
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` produces structured
+    // JSON output items. A "structured_output" response_item carries a JSON-validated
+    // content object as its payload. RawEntry must parse these without panicking.
+
+    #[test]
+    fn v0132_exec_resume_output_schema_structured_output_item_parses_correctly() {
+        let line = r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"ok","value":42}}}"#;
+        let e = RawEntry::parse(line).expect("structured_output response_item must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "structured_output");
+        assert_eq!(e.payload["content"]["result"], "ok");
+        assert_eq!(e.payload["content"]["value"], 42);
+    }
+
+    #[test]
+    fn v0132_exec_resume_output_schema_full_session_entry_types_parse_correctly() {
+        // Regression guard: all standard JSONL entry types plus structured_output must
+        // parse correctly for a v0.132.0 session run with --output-schema.
+        let lines = [
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-schema-session","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"done","items":["a","b"]}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "turn_context",
+            "response_item",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.132.0");
+        // The structured_output item content must be accessible via the payload.
+        let schema_item = RawEntry::parse(lines[3]).unwrap();
+        assert_eq!(schema_item.payload["type"], "structured_output");
+        assert_eq!(schema_item.payload["content"]["result"], "done");
+    }
+
     #[test]
     fn v0136_all_standard_entry_types_parse_correctly() {
         // Regression guard: all standard entry types plus shell_hook_output must parse

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -782,6 +782,36 @@ mod tests {
         assert_eq!(meta.payload["id"], "v0135-img-session");
     }
 
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` emits response_items with
+    // type "structured_output". The RawEntry parser must pass these through without panic.
+    // Downstream, handle_response_item (turn.rs) extracts the content as final_answer.
+
+    #[test]
+    fn v0132_structured_output_response_item_parses_correctly() {
+        let line = r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"done","count":42},"output_schema":{"type":"object","properties":{"result":{"type":"string"},"count":{"type":"integer"}}}}}"#;
+        let e = RawEntry::parse(line).expect("structured_output response_item must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "structured_output");
+        assert_eq!(e.payload["content"]["result"], "done");
+        assert_eq!(e.payload["content"]["count"], 42);
+    }
+
+    #[test]
+    fn v0132_session_meta_with_output_schema_field_parses_correctly() {
+        // session_meta from a session started with --output-schema carries an output_schema
+        // field in its payload. The loosely-typed RawEntry model ignores unknown fields, so
+        // this must parse without panic and produce the correct entry_type.
+        let line = r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-schema-session","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","output_schema":{"type":"object","properties":{"result":{"type":"string"}}}}}"#;
+        let e = RawEntry::parse(line).expect("session_meta with output_schema must parse");
+        assert_eq!(e.entry_type, "session_meta");
+        assert_eq!(e.payload["id"], "v0132-schema-session");
+        assert_eq!(e.payload["cli_version"], "0.132.0");
+        assert!(
+            e.payload.get("output_schema").is_some(),
+            "output_schema field must be accessible via payload"
+        );
+    }
+
     // Codex v0.136.0 (PR #24962): shell hook output event schemas tightened.
     // hook output events are now emitted as event_msg entries with type "shell_hook_output".
     // The strict schema requires call_id, hook_type, stdout, exit_code; previously nullable

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1231,10 +1231,9 @@ mod tests {
         assert_eq!(session.spawned_worker_ids, vec!["worker-137"]);
     }
 
-    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured JSON
-    // output for resumed automation sessions. Session transcripts contain response_items with
-    // type "structured_output" whose content is a schema-validated JSON object. parse_session
-    // must populate the turn's final_answer from these items rather than silently dropping them.
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` produces structured
+    // JSON output items. A full parse_session must capture the structured_output response_item
+    // content as the turn's final_answer so exec sessions with --output-schema display correctly.
 
     #[test]
     fn v0132_exec_resume_with_output_schema_captures_structured_final_answer() {
@@ -1271,6 +1270,43 @@ mod tests {
     }
 
     #[test]
+    fn v0132_parse_session_with_structured_output_populates_final_answer() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-20T10-00-00-v0132schema.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-schema-session","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:02Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
+                // structured_output item from --output-schema exec session
+                r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"success","count":7}}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0132-schema-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.132.0"));
+        assert_eq!(session.turns.len(), 1);
+        let turn = &session.turns[0];
+        assert!(
+            turn.final_answer.is_some(),
+            "structured_output response_item must populate final_answer"
+        );
+        let answer = turn.final_answer.as_ref().unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(answer).expect("final_answer must be valid JSON");
+        assert_eq!(v["result"], "success");
+        assert_eq!(v["count"], 7);
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
     fn v0132_exec_resume_with_output_schema_and_tool_calls_parses_fully() {
         // Full exec resume session: exec_command tool call followed by structured_output.
         // Verifies that both the tool call and the structured final answer are parsed correctly.
@@ -1302,6 +1338,41 @@ mod tests {
             .as_deref()
             .expect("final_answer must be captured from structured_output");
         assert!(answer.contains("main.rs"));
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn v0132_parse_session_with_message_json_content_populates_final_answer() {
+        // Codex v0.132.0+ (PR #23123): --output-schema sessions may emit the structured
+        // response as a "message" response_item where content is a JSON object.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-20T10-01-00-v0132msgschema.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-20T10:01:00Z","type":"session_meta","payload":{"id":"v0132-msg-schema","timestamp":"2026-05-20T10:01:00Z","cwd":"/tmp","cli_version":"0.132.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":{"status":"ok","output":"done"}}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606463.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0132-msg-schema");
+        assert_eq!(session.turns.len(), 1);
+        let turn = &session.turns[0];
+        assert!(
+            turn.final_answer.is_some(),
+            "message response_item with JSON content must populate final_answer"
+        );
+        let answer = turn.final_answer.as_ref().unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(answer).expect("final_answer must be valid JSON");
+        assert_eq!(v["status"], "ok");
         assert!(!session.is_ongoing);
     }
 

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1231,6 +1231,80 @@ mod tests {
         assert_eq!(session.spawned_worker_ids, vec!["worker-137"]);
     }
 
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured JSON
+    // output for resumed automation sessions. Session transcripts contain response_items with
+    // type "structured_output" whose content is a schema-validated JSON object. parse_session
+    // must populate the turn's final_answer from these items rather than silently dropping them.
+
+    #[test]
+    fn v0132_exec_resume_with_output_schema_captures_structured_final_answer() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-20T10-00-00-structured.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-structured-session","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","output_schema":{"type":"object","properties":{"result":{"type":"string"}}}}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"task completed successfully"}}}"#,
+                r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0132-structured-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.132.0"));
+        assert_eq!(session.turns.len(), 1);
+        let turn = &session.turns[0];
+        let answer = turn
+            .final_answer
+            .as_deref()
+            .expect("final_answer must be populated from structured_output response_item");
+        assert!(
+            answer.contains("task completed successfully"),
+            "final_answer must contain the structured JSON content"
+        );
+        assert!(!session.is_ongoing);
+    }
+
+    #[test]
+    fn v0132_exec_resume_with_output_schema_and_tool_calls_parses_fully() {
+        // Full exec resume session: exec_command tool call followed by structured_output.
+        // Verifies that both the tool call and the structured final answer are parsed correctly.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-05-20T10-01-00-structured-full.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-20T10:01:00Z","type":"session_meta","payload":{"id":"v0132-structured-full","timestamp":"2026-05-20T10:01:00Z","cwd":"/project","cli_version":"0.132.0","output_schema":{"type":"object","properties":{"files":{"type":"array"}}}}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls /project\",\"workdir\":\"/project\"}","call_id":"call_ls"}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_ls","aggregated_output":"main.rs\nCargo.toml\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":50000000}}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:04Z","type":"response_item","payload":{"type":"structured_output","content":{"files":["main.rs","Cargo.toml"]}}}"#,
+                r#"{"timestamp":"2026-05-20T10:01:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606465.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0132-structured-full");
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(session.turns[0].tool_calls.len(), 1);
+        assert_eq!(session.turns[0].tool_calls[0].name, "exec_command");
+        let answer = session.turns[0]
+            .final_answer
+            .as_deref()
+            .expect("final_answer must be captured from structured_output");
+        assert!(answer.contains("main.rs"));
+        assert!(!session.is_ongoing);
+    }
+
     #[test]
     fn v0137_session_without_spawn_agent_does_not_set_flag() {
         // Sessions with no spawn_agent calls must never set has_missing_spawn_metadata.

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -938,21 +938,29 @@ fn handle_response_item(
             }
         }
 
-        // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured
-        // JSON output for resumed automation sessions. Final model responses are emitted as
-        // response_items with type "structured_output" containing the schema-validated JSON
-        // object rather than a free-form text string. Without this handler, structured responses
-        // hit the `_ => {}` catch-all and the turn's final_answer is silently dropped.
+        // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` emits the final
+        // model response as a "structured_output" response_item whose `content` field holds a
+        // JSON object validated against the provided schema. Without this handler the item falls
+        // through to `_ => {}` and the turn's final_answer is never populated.
         "structured_output" => {
             if let Some(turn) = turns.get_mut(tid) {
                 if turn.final_answer.is_none() {
-                    let content = payload.get("content").or_else(|| payload.get("output"));
-                    if let Some(c) = content {
-                        let text = match c {
-                            Value::String(s) if !s.is_empty() => s.clone(),
-                            Value::String(_) => String::new(),
-                            other => serde_json::to_string(other).unwrap_or_default(),
-                        };
+                    let text = extract_item_content(payload);
+                    if !text.is_empty() {
+                        turn.final_answer = Some(text);
+                    }
+                }
+            }
+        }
+
+        // Handle assistant message response_items. This includes schema-validated JSON content
+        // from `codex exec resume --output-schema` (Codex v0.132.0+, PR #23123) where `content`
+        // is a JSON object rather than a plain string.
+        "message" => {
+            if payload.get("role").and_then(|v| v.as_str()) == Some("assistant") {
+                if let Some(turn) = turns.get_mut(tid) {
+                    if turn.final_answer.is_none() {
+                        let text = extract_item_content(payload);
                         if !text.is_empty() {
                             turn.final_answer = Some(text);
                         }
@@ -1010,6 +1018,26 @@ fn handle_turn_context(
                 turn.memories = memories;
             }
         }
+    }
+}
+
+/// Extract text from a response_item `content` field.
+/// Handles:
+/// - Plain strings (standard message content)
+/// - Content arrays (`[{"type":"text","text":"..."}]`, OpenAI format)
+/// - JSON objects (schema-validated responses from `codex exec resume --output-schema`,
+///   Codex v0.132.0+, PR #23123)
+fn extract_item_content(payload: &Value) -> String {
+    let content = payload.get("content").or_else(|| payload.get("output"));
+    match content {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(""),
+        Some(v) if !v.is_null() => serde_json::to_string(v).unwrap_or_default(),
+        _ => String::new(),
     }
 }
 
@@ -2815,34 +2843,32 @@ mod tests {
         assert_eq!(turns[0].tool_calls[0].kind, ToolKind::ShellHook);
     }
 
-    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured JSON
-    // output for resumed automation sessions. The final model response is emitted as a
-    // response_item with type "structured_output" carrying a schema-validated JSON object.
-    // Without explicit handling, it would silently fall into `_ => {}` and final_answer would
-    // remain None.
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` produces structured
+    // JSON output items. The final model response is emitted as a "structured_output"
+    // response_item with a JSON object in `content`. codex-trace must capture this as the
+    // turn's final_answer so exec sessions with --output-schema display correctly.
 
     #[test]
-    fn v0132_structured_output_response_item_sets_final_answer_from_object() {
+    fn v0132_structured_output_response_item_sets_final_answer() {
         let entries = entries(&[
-            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-structured","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-schema","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
             r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"done","count":42}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"success","count":42}}}"#,
             r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
         ]);
+
         let turns = build_turns(&entries);
         assert_eq!(turns.len(), 1);
-        let answer = turns[0]
-            .final_answer
-            .as_deref()
-            .expect("final_answer must be set from structured_output response_item");
+        let turn = &turns[0];
         assert!(
-            answer.contains("done"),
-            "answer must contain structured content"
+            turn.final_answer.is_some(),
+            "structured_output response_item must populate final_answer"
         );
-        assert!(
-            answer.contains("42"),
-            "answer must contain structured content"
-        );
+        let answer = turn.final_answer.as_ref().unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(answer).expect("final_answer must be valid JSON");
+        assert_eq!(v["result"], "success");
+        assert_eq!(v["count"], 42);
     }
 
     #[test]
@@ -2904,28 +2930,112 @@ mod tests {
     }
 
     #[test]
-    fn v0132_all_standard_entry_types_and_structured_output_in_complete_session() {
-        // Regression guard: all standard JSONL entry types plus a structured_output item
-        // must produce one complete turn with the expected final_answer.
+    fn v0132_message_response_item_with_json_object_content_sets_final_answer() {
+        // Codex v0.132.0+ (PR #23123): `--output-schema` sessions may emit the structured
+        // response as a "message" response_item where `content` is a JSON object rather than
+        // a plain string. This must populate final_answer so the turn is not left empty.
         let entries = entries(&[
-            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-full","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","output_schema":{"type":"object","properties":{"result":{"type":"string"}}}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-msg-schema","timestamp":"2026-05-20T10:00:00Z"}}"#,
             r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/tmp\"}","call_id":"call_ls"}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_ls","aggregated_output":"file.txt\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":50000000}}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:05Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"task completed successfully"}}}"#,
-            r#"{"timestamp":"2026-05-20T10:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606406.0}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":{"status":"done","items":["a","b"]}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
         ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert!(
+            turn.final_answer.is_some(),
+            "message response_item with JSON content must populate final_answer"
+        );
+        let answer = turn.final_answer.as_ref().unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(answer).expect("final_answer must be valid JSON");
+        assert_eq!(v["status"], "done");
+        assert_eq!(v["items"][0], "a");
+    }
+
+    #[test]
+    fn v0132_message_response_item_with_plain_string_sets_final_answer() {
+        // Plain-text assistant message response_items (common in exec sessions) must
+        // also populate final_answer.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-msg-plain","timestamp":"2026-05-20T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Task completed successfully."}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].final_answer.as_deref(),
+            Some("Task completed successfully.")
+        );
+    }
+
+    #[test]
+    fn v0132_task_complete_last_agent_message_overrides_message_item_final_answer() {
+        // task_complete.last_agent_message always overwrites final_answer (fires last in
+        // the stream). This test ensures the priority order is preserved.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-override","timestamp":"2026-05-20T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"preliminary answer"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0,"last_agent_message":"definitive answer from task_complete"}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].final_answer.as_deref(),
+            Some("definitive answer from task_complete")
+        );
+    }
+
+    #[test]
+    fn v0132_user_message_response_item_does_not_set_final_answer() {
+        // Only "assistant" role message response_items should populate final_answer;
+        // user-role items must not.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-user-msg","timestamp":"2026-05-20T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":"user request here"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert!(
+            turns[0].final_answer.is_none(),
+            "user-role message must not set final_answer"
+        );
+    }
+
+    #[test]
+    fn v0132_all_standard_entry_types_plus_structured_output_parse_correctly() {
+        // Regression guard: a v0.132.0 --output-schema session must parse all four
+        // standard entry types plus the structured_output response_item without error,
+        // and the turn must reach Complete status with final_answer populated.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-schema-full","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"status":"ok","value":99}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+        ]);
+
         let turns = build_turns(&entries);
         assert_eq!(turns.len(), 1);
         let turn = &turns[0];
         assert_eq!(turn.status, TurnStatus::Complete);
-        assert_eq!(turn.tool_calls.len(), 1);
-        assert_eq!(turn.tool_calls[0].kind, ToolKind::ExecCommand);
+        assert_eq!(turn.model.as_deref(), Some("gpt-5"));
         let answer = turn
             .final_answer
-            .as_deref()
-            .expect("final_answer must be set from structured_output response_item");
-        assert!(answer.contains("task completed successfully"));
+            .as_ref()
+            .expect("structured_output must set final_answer");
+        let v: serde_json::Value = serde_json::from_str(answer).expect("must be valid JSON");
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["value"], 99);
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -938,6 +938,29 @@ fn handle_response_item(
             }
         }
 
+        // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured
+        // JSON output for resumed automation sessions. Final model responses are emitted as
+        // response_items with type "structured_output" containing the schema-validated JSON
+        // object rather than a free-form text string. Without this handler, structured responses
+        // hit the `_ => {}` catch-all and the turn's final_answer is silently dropped.
+        "structured_output" => {
+            if let Some(turn) = turns.get_mut(tid) {
+                if turn.final_answer.is_none() {
+                    let content = payload.get("content").or_else(|| payload.get("output"));
+                    if let Some(c) = content {
+                        let text = match c {
+                            Value::String(s) if !s.is_empty() => s.clone(),
+                            Value::String(_) => String::new(),
+                            other => serde_json::to_string(other).unwrap_or_default(),
+                        };
+                        if !text.is_empty() {
+                            turn.final_answer = Some(text);
+                        }
+                    }
+                }
+            }
+        }
+
         _ => {}
     }
 }
@@ -2790,5 +2813,119 @@ mod tests {
         assert_eq!(turns[0].status, TurnStatus::Complete);
         assert_eq!(turns[0].tool_calls.len(), 1);
         assert_eq!(turns[0].tool_calls[0].kind, ToolKind::ShellHook);
+    }
+
+    // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` enforces structured JSON
+    // output for resumed automation sessions. The final model response is emitted as a
+    // response_item with type "structured_output" carrying a schema-validated JSON object.
+    // Without explicit handling, it would silently fall into `_ => {}` and final_answer would
+    // remain None.
+
+    #[test]
+    fn v0132_structured_output_response_item_sets_final_answer_from_object() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-structured","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"done","count":42}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+        ]);
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        let answer = turns[0]
+            .final_answer
+            .as_deref()
+            .expect("final_answer must be set from structured_output response_item");
+        assert!(
+            answer.contains("done"),
+            "answer must contain structured content"
+        );
+        assert!(
+            answer.contains("42"),
+            "answer must contain structured content"
+        );
+    }
+
+    #[test]
+    fn v0132_structured_output_with_string_content_sets_final_answer() {
+        // structured_output may carry a plain string in the content field rather than a
+        // JSON object when the schema resolves to a primitive type.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-str-output","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","content":"schema-validated plain text"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+        ]);
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].final_answer.as_deref(),
+            Some("schema-validated plain text"),
+            "string-typed structured_output content must be stored verbatim"
+        );
+    }
+
+    #[test]
+    fn v0132_structured_output_does_not_overwrite_existing_final_answer() {
+        // task_complete.last_agent_message takes precedence; a structured_output response_item
+        // that arrives before task_complete must not clobber the answer set by agent_message.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-priority","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"prior final answer","phase":"final_answer"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"response_item","payload":{"type":"structured_output","content":{"should":"not overwrite"}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606404.0}}"#,
+        ]);
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].final_answer.as_deref(),
+            Some("prior final answer"),
+            "structured_output must not overwrite an already-set final_answer"
+        );
+    }
+
+    #[test]
+    fn v0132_structured_output_output_field_fallback_sets_final_answer() {
+        // Some structured_output items may use `output` instead of `content`.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-output-field","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"structured_output","output":{"status":"ok","value":99}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606403.0}}"#,
+        ]);
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        let answer = turns[0]
+            .final_answer
+            .as_deref()
+            .expect("final_answer must be set from output field of structured_output");
+        assert!(answer.contains("ok"));
+        assert!(answer.contains("99"));
+    }
+
+    #[test]
+    fn v0132_all_standard_entry_types_and_structured_output_in_complete_session() {
+        // Regression guard: all standard JSONL entry types plus a structured_output item
+        // must produce one complete turn with the expected final_answer.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-05-20T10:00:00Z","type":"session_meta","payload":{"id":"v0132-full","timestamp":"2026-05-20T10:00:00Z","cwd":"/tmp","cli_version":"0.132.0","output_schema":{"type":"object","properties":{"result":{"type":"string"}}}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"ls\",\"workdir\":\"/tmp\"}","call_id":"call_ls"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call_ls","aggregated_output":"file.txt\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":50000000}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:04Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/tmp"}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:05Z","type":"response_item","payload":{"type":"structured_output","content":{"result":"task completed successfully"}}}"#,
+            r#"{"timestamp":"2026-05-20T10:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1748606406.0}}"#,
+        ]);
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.status, TurnStatus::Complete);
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_calls[0].kind, ToolKind::ExecCommand);
+        let answer = turn
+            .final_answer
+            .as_deref()
+            .expect("final_answer must be set from structured_output response_item");
+        assert!(answer.contains("task completed successfully"));
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -956,14 +956,12 @@ fn handle_response_item(
         // Handle assistant message response_items. This includes schema-validated JSON content
         // from `codex exec resume --output-schema` (Codex v0.132.0+, PR #23123) where `content`
         // is a JSON object rather than a plain string.
-        "message" => {
-            if payload.get("role").and_then(|v| v.as_str()) == Some("assistant") {
-                if let Some(turn) = turns.get_mut(tid) {
-                    if turn.final_answer.is_none() {
-                        let text = extract_item_content(payload);
-                        if !text.is_empty() {
-                            turn.final_answer = Some(text);
-                        }
+        "message" if payload.get("role").and_then(|v| v.as_str()) == Some("assistant") => {
+            if let Some(turn) = turns.get_mut(tid) {
+                if turn.final_answer.is_none() {
+                    let text = extract_item_content(payload);
+                    if !text.is_empty() {
+                        turn.final_answer = Some(text);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Adds support for parsing `structured_output` and `message` response_items emitted by Codex v0.132.0 when using `codex exec resume --output-schema`.

Fixes #126

## Problem

Codex v0.132.0 (upstream PR #23123) introduced the `--output-schema` flag for `codex exec resume`. When set, the final model response is emitted as a `response_item` with type `"structured_output"` whose `content` field holds a schema-validated JSON object, rather than a free-form text string.

Previously both `"structured_output"` and `"message"` response_item types fell through to `_ => {}` in `handle_response_item`, silently dropping the content and leaving the turn's `final_answer` unpopulated. This meant exec sessions run with `--output-schema` would show blank final answers in codex-trace.

## Changes

### `src-tauri/src/parser/turn.rs`

- Added explicit `"structured_output"` handler in `handle_response_item` — extracts `content` (falling back to `output`) and stores it as `final_answer` when none is already set
- Added explicit `"message"` handler for assistant-role items — handles schema-validated JSON content in the `content` field
- Added `extract_item_content` helper to handle all three content variants: plain strings, OpenAI-format content arrays (`[{"type":"text","text":"..."}]`), and raw JSON objects (the new structured output format)
- Guard `if turn.final_answer.is_none()` preserves the established `task_complete.last_agent_message` override priority

### `src-tauri/src/parser/entry.rs`

- Added regression tests verifying `structured_output` response_items parse correctly at the `RawEntry` layer

### `src-tauri/src/parser/session.rs`

- Added integration tests verifying a full `parse_session` pipeline populates `final_answer` from `structured_output` and `message` response_items

## Test results

- 222 Rust unit tests: all pass
- 135 frontend (vitest) tests: all pass
- `cargo clippy -- -D warnings`: clean
- HTTP API smoke test: `POST /api/sessions` returns `[]` (HTTP 200)
