### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ All notable changes to codex-trace are documented here. Versions follow
 [semantic versioning](https://semver.org/), and this file follows
 [Keep a Changelog](https://keepachangelog.com/) conventions.
 
+## [0.2.0] — 2026-06-16
+
+A readability upgrade for the turn view plus a sweep of parser compatibility with the
+latest Codex CLI releases (v0.132.0 through v0.139.0). If your sessions had blank final
+answers, missing memory notes, or tool calls that looked corrupted on newer Codex
+builds, this release fixes those — and the assistant's commentary now reads inline,
+in order, alongside the tool calls it interleaves with.
+
+### Added
+
+- **Assistant commentary renders inline**
+  ([`20d48f4`](https://github.com/PixelPaw-Labs/codex-trace/commit/20d48f4)). The
+  assistant's prose is now a first-class timeline item ("Complementary") shown expanded
+  by default, so a turn reads commentary → tool call → commentary → … → final answer top
+  to bottom instead of leaving the text as loose lines above a tool box.
+- **Image file paths from generated images**
+  ([`1deb184`](https://github.com/PixelPaw-Labs/codex-trace/commit/1deb184)). Codex
+  v0.138.0 attaches a `file_path` to image-generation results; codex-trace now surfaces
+  it so you can see where a generated image landed on disk.
+- **Archived-session awareness**
+  ([`fcc8bc4`](https://github.com/PixelPaw-Labs/codex-trace/commit/fcc8bc4)). Sessions
+  archived or unarchived via Codex v0.136.0's `codex archive` / `/archive` are now
+  tracked, so archived runs are recognized rather than shown as ordinary sessions.
+
+### Fixed
+
+- **Raw command output no longer corrupts tool-call details**
+  ([`6850c30`](https://github.com/PixelPaw-Labs/codex-trace/commit/6850c30)). On Codex
+  v0.133.0, exec output is kept verbatim; phrases like "exit code: 1" inside real output
+  were being mistaken for metadata. Exec metadata is now read only from the structured
+  `Output:` marker, so a compiler or test log can no longer fake an exit code or
+  duration.
+- **Tool calls with structured arguments are no longer dropped**
+  ([`f081fd0`](https://github.com/PixelPaw-Labs/codex-trace/commit/f081fd0)). Codex
+  v0.139.0 can emit `function_call` arguments as a JSON object rather than a string;
+  those calls now parse and display instead of showing up empty.
+- **Final answers from `--output-schema` runs now display**
+  ([`26f1874`](https://github.com/PixelPaw-Labs/codex-trace/commit/26f1874)). Codex
+  v0.132.0 `structured_output` / `message` response items were silently skipped, leaving
+  the final answer blank; they're now shown.
+- **Versioned memory summaries are parsed again**
+  ([`947f248`](https://github.com/PixelPaw-Labs/codex-trace/commit/947f248)). Codex
+  v0.132.0 made `turn_context` memories versioned objects instead of plain strings,
+  which dropped them from the view; both forms are now handled.
+- **Agent-interrupt events are recognized under their new name**
+  ([`b9f9bd1`](https://github.com/PixelPaw-Labs/codex-trace/commit/b9f9bd1)). Codex
+  v0.139.0 renamed `close_agent` to `interrupt_agent`; both names are now classified
+  correctly, so multi-agent runs keep displaying these events.
+
+### Changed
+
+- **Fonts aligned with claude-code-trace**
+  ([`20d48f4`](https://github.com/PixelPaw-Labs/codex-trace/commit/20d48f4)). Detail-view
+  text now uses fixed `px` sizing (13px prose) instead of `rem`, so type no longer
+  rescales with browser/OS root font settings.
+
+[0.2.0]: https://github.com/PixelPaw-Labs/codex-trace/releases/tag/v0.2.0
+
 ## [0.1.0] — 2026-06-08
 
 The first release of Codex Trace — a desktop app for browsing and inspecting your

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-trace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-trace",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-fs": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-trace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "bin": {
     "codex-trace": "./bin/codex-trace.mjs"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "codex-trace"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-trace"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Codex Trace",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.codextrace.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Release **v0.2.0**, cut with the `cut-release` skill (baseline `v0.1.0`, 11 commits since; highest tier `feat:` → minor bump).

## Version bump (lockstep, version-only diff)
- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` → `0.2.0`
- `package-lock.json`, `src-tauri/Cargo.lock` regenerated

## CHANGELOG `## [0.2.0] — 2026-06-16`
**Added** — inline assistant commentary (`#116`), image file paths from Codex v0.138.0 (`#129`), archived-session awareness from v0.136.0 (`#132`).
**Fixed** — raw exec output no longer fakes tool-call metadata (v0.133.0, `#133`); JSON-object `function_call` arguments no longer dropped (v0.139.0, `#130`); `--output-schema` final answers display (v0.132.0, `#131`); versioned memory summaries parsed (v0.132.0, `#128`); `close_agent`→`interrupt_agent` recognized (v0.139.0, `#127`).
**Changed** — detail-view fonts use fixed `px` (`#116`).

All 11 source PRs were authored by the maintainer (`delexw`), so no contributor attribution lines were added. `chore(deps)` PRs (#117–#119) were skipped per skill rules.

## Verification
`npm run check` green (tsc + oxlint + oxfmt + clippy + cargo fmt + vitest + cargo test). The CHANGELOG heading matches the exact `## [X.Y.Z] — YYYY-MM-DD` format the release pipeline's `notes` job requires.

## How to publish after merge
This session can't push tags/`main` (sandbox restriction), so the tag isn't pushed here. Once merged:
- **Tag-driven (full build):** push `v0.2.0` → runs guard → notes → macOS/Linux/Windows build → publish; **or**
- **Manual (no artifacts):** run the **Release** workflow via `workflow_dispatch` with version `0.2.0` — the `manual-release` job tags `v0.2.0` at `main` and publishes the GitHub release from the CHANGELOG. I can trigger this for you via the GitHub API once merged.

https://claude.ai/code/session_01FLcTQTp5efCHTgWrpbYf64

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLcTQTp5efCHTgWrpbYf64)_