### PR TITLE
[#142]: fix(parser): classify context-budget tools as ContextQuery for Codex v0.140.0 compat

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -68,6 +68,9 @@ export type ToolKind =
   | "followup_task"
   /** Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks. */
   | "shell_hook"
+  /** Codex v0.140.0 (PRs #27438, #27488, #27518): built-in runtime tools for querying the
+   * remaining context budget (`token_budget_context`, `context_remaining`, `context_window`). */
+  | "context_query"
   | "unknown";
 
 export interface CodexToolCall {

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -21,6 +21,10 @@ pub enum ToolKind {
     FollowupTask,
     /// Codex v0.136.0 (PR #24962): shell hook outputs from pre/post-tool lifecycle hooks.
     ShellHook,
+    /// Codex v0.140.0 (PRs #27438, #27488, #27518): built-in runtime tools that the model
+    /// invokes to query the remaining context budget. Covers `token_budget_context`,
+    /// `context_remaining`, and `context_window`.
+    ContextQuery,
     Unknown,
 }
 
@@ -307,6 +311,45 @@ impl ToolCallBuilder {
                     image_file_path: None,
                     worker_session: None,
                     status: spawn_agent_status(output),
+                    subagent_id: None,
+                    subagent_name: None,
+                });
+                return;
+            }
+
+            // Codex v0.140.0 (PRs #27438, #27488, #27518): built-in context-budget query tools.
+            // token_budget_context, context_remaining, and context_window are invoked by the
+            // model during turns; classify as ContextQuery for enriched display.
+            if matches!(
+                pending.name.as_str(),
+                "token_budget_context" | "context_remaining" | "context_window"
+            ) {
+                self.finalized.push(ToolCall {
+                    call_id: call_id.to_string(),
+                    kind: ToolKind::ContextQuery,
+                    name: pending.name,
+                    arguments: pending.arguments,
+                    input_text: pending.input_text,
+                    output: if output.is_empty() {
+                        None
+                    } else {
+                        Some(output.to_string())
+                    },
+                    exit_code: None,
+                    command: None,
+                    cwd: None,
+                    duration_secs: None,
+                    mcp_server: None,
+                    mcp_tool: None,
+                    plugin_id: None,
+                    patch_success: None,
+                    patch_changes: None,
+                    web_query: None,
+                    web_url: None,
+                    image_prompt: None,
+                    image_file_path: None,
+                    worker_session: None,
+                    status: "completed".to_string(),
                     subagent_id: None,
                     subagent_name: None,
                 });
@@ -2016,6 +2059,95 @@ mod tests {
             tool.status, "completed",
             "status must be completed for raw output without failure signal"
         );
+    }
+
+    // Codex v0.140.0 (PRs #27438, #27488, #27518): three new built-in context-budget tools.
+    // token_budget_context, context_remaining, and context_window appear in session transcripts
+    // as function_call / function_call_output pairs. They must be classified as ContextQuery,
+    // not Unknown, and must not panic or produce parse errors.
+
+    #[test]
+    fn v0140_token_budget_context_classified_as_context_query() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_budget".to_string(),
+            "token_budget_context".to_string(),
+            r#"{}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output(
+            "call_budget",
+            r#"{"tokens_used":12345,"tokens_remaining":87655}"#,
+            None,
+        );
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ContextQuery);
+        assert_eq!(tool.name, "token_budget_context");
+        assert_eq!(tool.status, "completed");
+        assert!(tool.output.is_some());
+    }
+
+    #[test]
+    fn v0140_context_remaining_classified_as_context_query() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_ctx".to_string(),
+            "context_remaining".to_string(),
+            r#"{}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_ctx", r#"{"remaining":50000}"#, None);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ContextQuery);
+        assert_eq!(tool.name, "context_remaining");
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn v0140_context_window_classified_as_context_query() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_win".to_string(),
+            "context_window".to_string(),
+            r#"{}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_win", r#"{"window_size":128000}"#, None);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ContextQuery);
+        assert_eq!(tool.name, "context_window");
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn v0140_context_query_with_empty_output_yields_none() {
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_empty".to_string(),
+            "token_budget_context".to_string(),
+            r#"{}"#,
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_empty", "", None);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::ContextQuery);
+        assert!(tool.output.is_none(), "empty output should yield None");
     }
 
     #[test]

--- a/src/components/ToolCallItem.tsx
+++ b/src/components/ToolCallItem.tsx
@@ -50,6 +50,7 @@ function kindIcon(kind: CodexToolCall["kind"], failed: boolean) {
       return <FollowupTaskIcon />;
     case "shell_hook":
       return <HookIcon />;
+    case "context_query":
     default:
       return <UnknownToolIcon />;
   }
@@ -74,6 +75,7 @@ function kindClass(kind: CodexToolCall["kind"]): string {
       return "tool-call--collab";
     case "shell_hook":
       return "tool-call--hook";
+    case "context_query":
     default:
       return "tool-call--unknown";
   }
@@ -306,7 +308,7 @@ function ToolCallBody({ tool, popout = false }: { tool: CodexToolCall; popout?: 
           </div>
         )}
 
-      {tool.kind === "unknown" &&
+      {(tool.kind === "unknown" || tool.kind === "context_query") &&
         tool.arguments != null &&
         Object.keys(tool.arguments).length > 0 && (
           <div className="tool-call__section tool-call__section--input">


### PR DESCRIPTION
## Summary

Fixes #142

Codex v0.140.0 added three built-in runtime tools that the model invokes during turns to query the remaining context budget:

- `token_budget_context` (PR #27438)
- `context_window` (PR #27488)
- `context_remaining` (PR #27518)

These tools appear in session transcripts as `function_call` / `function_call_output` pairs. Without this fix, they fall through to the `Unknown` classification in the parser, producing generic rendering with no semantic identification.

## Changes

### `src-tauri/src/parser/toolcall.rs`
- Added `ContextQuery` variant to the `ToolKind` enum (with Codex version/PR attribution).
- In `add_function_call_output`, added a named match branch before the `Unknown` fallthrough that classifies `token_budget_context`, `context_remaining`, and `context_window` as `ContextQuery`.
- Added 4 new unit tests covering all three tool names plus the empty-output edge case.

### `shared/types.ts`
- Added `"context_query"` to the `ToolKind` TypeScript union (with version/PR attribution comment).

### `src/components/ToolCallItem.tsx`
- Added explicit `"context_query"` cases to `kindIcon` and `kindClass` (uses `UnknownToolIcon` / `tool-call--unknown` styling).
- Extended the arguments display condition to include `"context_query"` alongside `"unknown"` so any arguments are shown in the tool body.

## Testing

- 4 new Rust unit tests covering all three tool names plus empty-output edge case.
- All 265 Rust tests pass.
- All 135 frontend (vitest) tests pass.
- Clippy (`-D warnings`), `oxlint`, `oxfmt --check`, and `tsc --noEmit` all clean.
