### PR TITLE
[#144]: compat: verify ResponseItem metadata field for Codex v0.141.0

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1013,6 +1013,74 @@ mod tests {
         );
     }
 
+    // Codex v0.141.0 (PR #28355): ResponseItem gains a new optional top-level `metadata` field.
+    // The field carries additional per-item structured data populated by the server in certain
+    // response flows. RawEntry must parse response_items with a metadata field without error,
+    // and the field must be accessible via entry.payload so downstream consumers can read it.
+
+    #[test]
+    fn v0141_response_item_with_metadata_field_parses_correctly() {
+        let line = r#"{"timestamp":"2026-06-18T10:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello","metadata":{"server_key":"srv-abc123","model_version":"gpt-5.4-preview","trace_id":"trace-xyz"}}}"#;
+        let e = RawEntry::parse(line).expect("response_item with metadata must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "message");
+        // metadata field must be accessible and preserved round-trip
+        let meta = &e.payload["metadata"];
+        assert!(!meta.is_null(), "metadata field must be present");
+        assert_eq!(meta["server_key"], "srv-abc123");
+        assert_eq!(meta["trace_id"], "trace-xyz");
+    }
+
+    #[test]
+    fn v0141_response_item_without_metadata_is_backward_compatible() {
+        // Pre-v0.141.0 sessions must still parse normally when metadata is absent.
+        let line = r#"{"timestamp":"2026-06-18T10:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#;
+        let e = RawEntry::parse(line).expect("response_item without metadata must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "message");
+        assert!(
+            e.payload.get("metadata").is_none(),
+            "metadata must be absent in pre-v0.141.0 entries"
+        );
+    }
+
+    #[test]
+    fn v0141_function_call_response_item_with_metadata_parses_correctly() {
+        let line = r#"{"timestamp":"2026-06-18T10:00:01Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call_meta_1","arguments":"{\"cmd\":\"echo hi\"}","metadata":{"priority":"high","request_id":"req-789"}}}"#;
+        let e = RawEntry::parse(line).expect("function_call with metadata must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "function_call");
+        assert_eq!(e.payload["metadata"]["priority"], "high");
+        assert_eq!(e.payload["metadata"]["request_id"], "req-789");
+    }
+
+    #[test]
+    fn v0141_all_standard_entry_types_parse_correctly() {
+        let lines = [
+            r#"{"timestamp":"2026-06-18T10:00:00Z","type":"session_meta","payload":{"id":"v0141-session","timestamp":"2026-06-18T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello","metadata":{"server_key":"srv-v0141","trace_id":"trace-0141"}}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750240804.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.141.0");
+        // metadata field must be preserved on the response_item payload
+        let msg_entry = RawEntry::parse(lines[2]).unwrap();
+        assert_eq!(msg_entry.payload["metadata"]["server_key"], "srv-v0141");
+    }
+
     // Codex v0.139.0 (PRs #24118, #27084): tool and connector input schemas now preserve
     // oneOf and allOf structures instead of flattening them. Large schemas also keep more
     // shallow structure when compacted.

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1557,4 +1557,48 @@ mod tests {
         assert_eq!(tool.status, "completed");
         assert!(!session.is_ongoing);
     }
+
+    // Codex v0.141.0 (PR #28355): ResponseItem gains a new optional top-level `metadata` field.
+    // parse_session must handle response_items with a metadata field without error; the tool
+    // call and agent message pipelines must produce correct results regardless of the field.
+
+    #[test]
+    fn v0141_parse_session_with_response_item_metadata_field() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-06-18T10-00-00-v0141meta.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-06-18T10:00:00Z","type":"session_meta","payload":{"id":"v0141-meta-session","timestamp":"2026-06-18T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-06-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-06-18T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-v141-meta","arguments":"{\"cmd\":\"echo hello\"}","metadata":{"priority":"normal","request_id":"req-meta-v141"}}}"#,
+                r#"{"timestamp":"2026-06-18T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call-v141-meta","aggregated_output":"hello\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":20000000}}}"#,
+                r#"{"timestamp":"2026-06-18T10:00:04Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Done","metadata":{"server_key":"srv-0141","usage":{"prompt_tokens":5,"completion_tokens":2}}}}"#,
+                r#"{"timestamp":"2026-06-18T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750240805.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0141-meta-session");
+        assert_eq!(session.cli_version.as_deref(), Some("0.141.0"));
+        assert_eq!(session.turns.len(), 1);
+        // tool call must be created correctly despite the metadata field on the function_call
+        assert_eq!(session.turns[0].tool_calls.len(), 1);
+        let tool = &session.turns[0].tool_calls[0];
+        assert_eq!(tool.name, "exec_command");
+        assert_eq!(tool.output.as_deref(), Some("hello\n"));
+        assert_eq!(tool.exit_code, Some(0));
+        // assistant message response_item populates final_answer; the metadata field must not
+        // prevent the content from being extracted
+        assert_eq!(
+            session.turns[0].final_answer.as_deref(),
+            Some("Done"),
+            "message with metadata must populate final_answer"
+        );
+        assert!(!session.is_ongoing);
+    }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -3282,4 +3282,54 @@ mod tests {
         assert!(tool.arguments.get("options").is_some());
         assert_eq!(tool.output.as_deref(), Some("submitted"));
     }
+
+    // Codex v0.141.0 (PR #28355): ResponseItem gains a new optional top-level `metadata` field.
+    // build_turns must handle response_items carrying a metadata field without error; tool call
+    // extraction and agent message building must be unaffected.
+
+    #[test]
+    fn v0141_response_item_with_metadata_does_not_affect_turn_building() {
+        let lines = [
+            r#"{"timestamp":"2026-06-18T10:00:00Z","type":"session_meta","payload":{"id":"v0141-turn-meta","timestamp":"2026-06-18T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-v141","arguments":"{\"cmd\":\"echo hi\"}","metadata":{"priority":"normal","request_id":"req-v141"}}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call-v141","aggregated_output":"hi\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":10000000}}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750240804.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(tool.name, "exec_command");
+        assert_eq!(tool.output.as_deref(), Some("hi\n"));
+        assert_eq!(tool.exit_code, Some(0));
+        assert_eq!(tool.status, "completed");
+    }
+
+    #[test]
+    fn v0141_message_response_item_with_metadata_populates_final_answer() {
+        let lines = [
+            r#"{"timestamp":"2026-06-18T10:01:00Z","type":"session_meta","payload":{"id":"v0141-msg-meta","timestamp":"2026-06-18T10:01:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Done!","metadata":{"server_key":"srv-v141","usage":{"prompt_tokens":10,"completion_tokens":5}}}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-2","completed_at":1750240863.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        // assistant message response_item populates final_answer; the metadata field must not
+        // prevent the content from being extracted
+        assert_eq!(
+            turns[0].final_answer.as_deref(),
+            Some("Done!"),
+            "message with metadata must populate final_answer"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Codex v0.141.0 (PR #28355: "feat(core): add metadata field to ResponseItem") adds an optional top-level `metadata` field to all `ResponseItem` entries in session JSONL files. This field carries additional per-item structured data populated by the server in certain response flows.

The codex-trace parser already uses `serde_json::Value` for all JSONL payloads (`RawEntry.payload`), so strict-deserialization parse failures cannot occur — the `metadata` field is simply preserved in the payload `Value` and is accessible to downstream consumers. No schema changes are required.

This PR adds explicit test coverage across all three parser layers to guard round-trip fidelity and document the compatibility behaviour.

## Changes

**`src-tauri/src/parser/entry.rs`** — 4 new tests:
- `v0141_response_item_with_metadata_field_parses_correctly`: confirms a `message` response_item with a populated `metadata` field parses without error and the field is accessible via `entry.payload["metadata"]`
- `v0141_response_item_without_metadata_is_backward_compatible`: confirms pre-v0.141.0 entries with no `metadata` field still parse correctly
- `v0141_function_call_response_item_with_metadata_parses_correctly`: confirms a `function_call` response_item with `metadata` field parses and the field is accessible
- `v0141_all_standard_entry_types_parse_correctly`: regression guard for all four standard JSONL entry types in a v0.141.0 session

**`src-tauri/src/parser/turn.rs`** — 2 new tests:
- `v0141_response_item_with_metadata_does_not_affect_turn_building`: confirms `build_turns` produces correct tool-calls (name, output, exit_code, status) for function_call items carrying a `metadata` field
- `v0141_message_response_item_with_metadata_populates_final_answer`: confirms assistant `message` response_items with a `metadata` field still populate `final_answer` correctly

**`src-tauri/src/parser/session.rs`** — 1 new test:
- `v0141_parse_session_with_response_item_metadata_field`: end-to-end session parse confirming correct turns, tool-calls, and `final_answer` for a v0.141.0 session with metadata-bearing response_items

## Verification

All 403 tests pass (268 Rust + 135 vitest), clippy `-D warnings` clean.

Fixes #144
