### PR TITLE
[#143]: fix(parser): handle external-agent import item types for Codex v0.140.0/v0.141.0 compat

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1095,4 +1095,83 @@ mod tests {
         let e = RawEntry::parse(line).expect("session_unarchived must parse");
         assert_eq!(e.entry_type, "session_unarchived");
     }
+
+    // Codex v0.140.0 (PRs #27070, #27071, #27703): /import command imports setup, project
+    // config, and recent chats from external agents (e.g. Claude Code). The import flow
+    // writes new event_msg entries describing the import lifecycle into session transcripts.
+    //
+    // Codex v0.141.0 (PR #28008): external_agent_import_result is a new accounting-type
+    // response_item that records token/cost totals for an imported external agent context.
+    //
+    // RawEntry must parse all of these without panicking; unknown entry types flow through
+    // the parser via the loosely-typed serde_json::Value model.
+
+    #[test]
+    fn v0140_agent_context_import_event_msg_parses_correctly() {
+        let line = r#"{"timestamp":"2026-06-15T10:00:00Z","type":"event_msg","payload":{"type":"agent_context_imported","source":"claude-code","thread_count":3,"token_count":12400}}"#;
+        let e = RawEntry::parse(line).expect("agent_context_imported event_msg must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(
+            e.payload.get("type").and_then(|t| t.as_str()),
+            Some("agent_context_imported")
+        );
+        assert_eq!(e.payload["source"], "claude-code");
+    }
+
+    #[test]
+    fn v0141_external_agent_import_result_response_item_parses_correctly() {
+        // v0.141.0 (PR #28008): accounting-type response_item for imported agent context.
+        let line = r#"{"timestamp":"2026-06-15T10:00:01Z","type":"response_item","payload":{"type":"external_agent_import_result","source":"claude-code","imported_thread_ids":["t1","t2"],"total_tokens":12400}}"#;
+        let e = RawEntry::parse(line).expect("external_agent_import_result must parse");
+        assert_eq!(e.entry_type, "response_item");
+        assert_eq!(e.payload["type"], "external_agent_import_result");
+        assert_eq!(e.payload["source"], "claude-code");
+        assert_eq!(e.payload["total_tokens"], 12400);
+    }
+
+    #[test]
+    fn v0140_all_standard_entry_types_plus_import_items_parse_correctly() {
+        // Regression guard: all standard JSONL entry types plus import-related entries
+        // must parse correctly for a v0.140.0 session that used /import.
+        let lines = [
+            r#"{"timestamp":"2026-06-15T10:00:00Z","type":"session_meta","payload":{"id":"v0140-import-session","timestamp":"2026-06-15T10:00:00Z","cwd":"/project","cli_version":"0.140.0","model_provider":"openai"}}"#,
+            // Import lifecycle event preceding the first turn
+            r#"{"timestamp":"2026-06-15T10:00:01Z","type":"event_msg","payload":{"type":"agent_context_imported","source":"claude-code","thread_count":2}}"#,
+            // Standard turn entries
+            r#"{"timestamp":"2026-06-15T10:00:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:03Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            // v0.141.0 accounting item inside the turn
+            r#"{"timestamp":"2026-06-15T10:00:04Z","type":"response_item","payload":{"type":"external_agent_import_result","source":"claude-code","total_tokens":12400}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:05Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750000006.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "event_msg",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.140.0");
+        assert_eq!(meta.payload["id"], "v0140-import-session");
+        // Import event is accessible
+        let import_entry = RawEntry::parse(lines[1]).unwrap();
+        assert_eq!(
+            import_entry.payload.get("type").and_then(|t| t.as_str()),
+            Some("agent_context_imported")
+        );
+        // Accounting item is accessible
+        let accounting_entry = RawEntry::parse(lines[4]).unwrap();
+        assert_eq!(
+            accounting_entry.payload["type"],
+            "external_agent_import_result"
+        );
+    }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -676,6 +676,16 @@ fn handle_event_msg(
         // skipped so they don't corrupt turn data.
         "goal_created" | "goal_updated" | "goal_completed" | "goal_paused" => {}
 
+        // Codex v0.140.0 (PRs #27070, #27071, #27703): /import command emits event_msg
+        // lifecycle events as it imports agent context into the session. These events modify
+        // the thread's initial context but carry no turn-building semantics for codex-trace
+        // — they are treated as pass-through so sessions beginning with imported context
+        // parse correctly without corrupting turn state.
+        "agent_context_import_started"
+        | "agent_context_imported"
+        | "external_agent_import_started"
+        | "external_agent_imported" => {}
+
         _ => {}
     }
 }
@@ -961,6 +971,17 @@ fn handle_response_item(
                 }
             }
         }
+
+        // Codex v0.140.0 (PRs #27070, #27071, #27703): /import command imports setup, project
+        // config, and recent chats from external agents (e.g. Claude Code). The import flow
+        // writes response_items into the session transcript describing imported threads. These
+        // items carry no turn-building semantics for codex-trace — treated as pass-through so
+        // callers never receive a hard error on sessions that include imported context.
+        //
+        // Codex v0.141.0 (PR #28008): external_agent_import_result is an accounting-type
+        // response_item that records token/cost totals for an imported agent context. It has
+        // no effect on turns or tool calls — treated as pass-through.
+        "external_agent_import_result" => {}
 
         // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` emits the final
         // model response as a "structured_output" response_item whose `content` field holds a
@@ -3281,5 +3302,105 @@ mod tests {
         assert!(!tool.arguments.is_null());
         assert!(tool.arguments.get("options").is_some());
         assert_eq!(tool.output.as_deref(), Some("submitted"));
+    }
+
+    // Codex v0.140.0 (PRs #27070, #27071, #27703): /import command adds external-agent
+    // context import event_msg entries and external_agent_import_result response_items.
+    // Sessions may now begin with import lifecycle events before the first task_started.
+    // Turn boundary detection must not be disrupted by these pre-turn entries.
+    //
+    // Codex v0.141.0 (PR #28008): external_agent_import_result accounting response_items
+    // may appear inside turns; they carry no turn-building semantics.
+
+    #[test]
+    fn v0140_import_event_before_first_turn_does_not_corrupt_turns() {
+        // Import lifecycle events appear before the first task_started.
+        // Verify that turns are built correctly and the import events don't create
+        // spurious synthetic turns or corrupt the first real turn.
+        let lines = [
+            r#"{"timestamp":"2026-06-15T10:00:00Z","type":"session_meta","payload":{"id":"v0140-pre-turn-import","timestamp":"2026-06-15T10:00:00Z","cwd":"/project","cli_version":"0.140.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:01Z","type":"event_msg","payload":{"type":"agent_context_imported","source":"claude-code","thread_count":2}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:03Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Imported context loaded, continuing session."}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750000004.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        // Exactly one turn must be built — the import event must not create a synthetic turn
+        assert_eq!(
+            turns.len(),
+            1,
+            "import event must not create spurious turns"
+        );
+        assert_eq!(turns[0].turn_id, "turn-1");
+        assert_eq!(turns[0].status, super::TurnStatus::Complete);
+    }
+
+    #[test]
+    fn v0141_external_agent_import_result_inside_turn_does_not_corrupt_turn() {
+        // external_agent_import_result (v0.141.0, PR #28008) is an accounting response_item
+        // that may appear inside a turn. It must not break tool-call or message extraction.
+        let lines = [
+            r#"{"timestamp":"2026-06-15T10:00:00Z","type":"session_meta","payload":{"id":"v0141-import-result","timestamp":"2026-06-15T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"echo hi\"}","call_id":"call-1"}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"hi\n"}}"#,
+            // Accounting item — must be silently ignored
+            r#"{"timestamp":"2026-06-15T10:00:04Z","type":"response_item","payload":{"type":"external_agent_import_result","source":"claude-code","total_tokens":8200}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"Done."}}"#,
+            r#"{"timestamp":"2026-06-15T10:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750000006.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        // Tool call is intact
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_calls[0].name, "exec_command");
+        assert_eq!(turn.tool_calls[0].output.as_deref(), Some("hi\n"));
+        // Agent message is intact
+        assert_eq!(turn.agent_messages.len(), 1);
+        assert_eq!(turn.agent_messages[0].text, "Done.");
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+    }
+
+    #[test]
+    fn v0140_all_standard_entry_types_plus_import_items_build_correct_turns() {
+        // Regression guard: a v0.140.0 session with import events must build the same
+        // turns as an equivalent session without import events.
+        let lines = [
+            r#"{"timestamp":"2026-06-15T10:02:00Z","type":"session_meta","payload":{"id":"v0140-full","timestamp":"2026-06-15T10:02:00Z","cwd":"/project","cli_version":"0.140.0","model_provider":"openai"}}"#,
+            // Pre-turn import event
+            r#"{"timestamp":"2026-06-15T10:02:01Z","type":"event_msg","payload":{"type":"external_agent_imported","source":"claude-code","imported_count":3}}"#,
+            r#"{"timestamp":"2026-06-15T10:02:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-15T10:02:03Z","type":"event_msg","payload":{"type":"user_message","message":"Continue with imported context"}}"#,
+            r#"{"timestamp":"2026-06-15T10:02:04Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Understood."}}"#,
+            r#"{"timestamp":"2026-06-15T10:02:05Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            // Accounting item inside the turn
+            r#"{"timestamp":"2026-06-15T10:02:06Z","type":"response_item","payload":{"type":"external_agent_import_result","source":"claude-code","total_tokens":5100}}"#,
+            r#"{"timestamp":"2026-06-15T10:02:07Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750000927.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1, "import events must not create extra turns");
+        let turn = &turns[0];
+        assert_eq!(turn.turn_id, "turn-1");
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+        assert_eq!(
+            turn.user_message.as_deref(),
+            Some("Continue with imported context")
+        );
+        assert_eq!(turn.model.as_deref(), Some("gpt-5"));
+        // No tool calls — the external_agent_import_result must not be misclassified
+        assert_eq!(turn.tool_calls.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Adds compatibility handling for Codex v0.140.0/v0.141.0 external-agent import item types introduced by the `/import` command.

## Background

Codex v0.140.0 (PRs #27070, #27071, #27703) added the `/import` command, which imports setup, project config, and recent chats from external agents (e.g. Claude Code). When used, the import flow writes new `event_msg` lifecycle entries into session transcripts — including entries that appear **before** the first `task_started` event. Codex v0.141.0 (PR #28008) added `external_agent_import_result`, a new accounting-type `response_item` that records token/cost totals for imported agent context.

## Changes

### `src-tauri/src/parser/turn.rs`

- Added explicit named handlers in `handle_event_msg` for `/import` lifecycle event_msg types (`agent_context_import_started`, `agent_context_imported`, `external_agent_import_started`, `external_agent_imported`). These are treated as pass-through no-ops with version/PR documentation.
- Added explicit named handler in `handle_response_item` for `external_agent_import_result` (v0.141.0 accounting type). Treated as pass-through.
- Added 3 tests:
  - `v0140_import_event_before_first_turn_does_not_corrupt_turns` — import events before `task_started` must not create spurious synthetic turns
  - `v0141_external_agent_import_result_inside_turn_does_not_corrupt_turn` — accounting item inside a turn must not break tool calls or agent messages
  - `v0140_all_standard_entry_types_plus_import_items_build_correct_turns` — full turn integrity regression guard for v0.140.0 sessions with import items

### `src-tauri/src/parser/entry.rs`

- Added 3 tests:
  - `v0140_agent_context_import_event_msg_parses_correctly` — import lifecycle event_msg parses without panicking
  - `v0141_external_agent_import_result_response_item_parses_correctly` — accounting response_item parses correctly
  - `v0140_all_standard_entry_types_plus_import_items_parse_correctly` — full v0.140.0 session regression guard

## Why no structural parser changes?

The `RawEntry` parser already uses a loosely-typed `serde_json::Value` model, so new entry types flow through without hard errors. The existing `_ => {}` catch-alls in `handle_event_msg` and `handle_response_item` already silently ignored these types. This PR adds **explicit named arms** for the known import types to document the intended behaviour for future readers, plus tests to lock in that sessions with imported context parse cleanly.

## Verification

All 267 Rust tests pass (`cargo test --manifest-path src-tauri/Cargo.toml`), all 135 frontend tests pass (`npx vitest run`), `cargo clippy -- -D warnings` is clean, and `oxlint`/`oxfmt` report no issues.

Fixes #143
