### PR TITLE
[#146]: fix(parser): handle dynamic tool namespaces from Codex v0.141.0 ThreadStart events

### DIFF
--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -80,6 +80,10 @@ pub struct ToolCallBuilder {
     pub finalized: Vec<ToolCall>,
     pty_sessions: HashMap<String, String>,
     running_exec_call_ids: Vec<String>,
+    /// Codex v0.141.0+ (PRs #27365, #27371): maps tool names to (tool_type, server).
+    /// Populated from the `dynamic_tools` field in `task_started` events.
+    /// Used to classify MCP/connector tools that arrive without a namespace field.
+    dynamic_tool_registry: HashMap<String, (String, String)>,
 }
 
 impl ToolCallBuilder {
@@ -89,7 +93,13 @@ impl ToolCallBuilder {
             finalized: Vec::new(),
             pty_sessions: HashMap::new(),
             running_exec_call_ids: Vec::new(),
+            dynamic_tool_registry: HashMap::new(),
         }
+    }
+
+    /// Set the dynamic tool registry built from `task_started.dynamic_tools` (Codex v0.141.0+).
+    pub fn set_dynamic_tool_registry(&mut self, registry: HashMap<String, (String, String)>) {
+        self.dynamic_tool_registry = registry;
     }
 
     /// Register a function_call (response_item).
@@ -364,7 +374,29 @@ impl ToolCallBuilder {
                     _ if pending.name == "close_agent" || pending.name == "interrupt_agent" => {
                         (ToolKind::InterruptAgent, None, None)
                     }
-                    _ => (ToolKind::Unknown, None, None),
+                    _ => {
+                        // v0.141.0+ (PRs #27365, #27371): tool name may be namespace-qualified
+                        // as "mcp:server/tool_name" or looked up via dynamic_tools registry.
+                        if let Some((tool_type, server, tool)) =
+                            parse_namespaced_tool_name(&pending.name)
+                        {
+                            match tool_type.as_str() {
+                                "mcp" => (ToolKind::McpTool, Some(server), Some(tool)),
+                                _ => (ToolKind::Unknown, None, None),
+                            }
+                        } else if let Some((tool_type, server)) =
+                            self.dynamic_tool_registry.get(&pending.name).cloned()
+                        {
+                            match tool_type.as_str() {
+                                "mcp" => {
+                                    (ToolKind::McpTool, Some(server), Some(pending.name.clone()))
+                                }
+                                _ => (ToolKind::Unknown, None, None),
+                            }
+                        } else {
+                            (ToolKind::Unknown, None, None)
+                        }
+                    }
                 }
             };
             let plugin_id = if kind == ToolKind::McpTool {
@@ -543,6 +575,7 @@ impl ToolCallBuilder {
 
         // Extract server + tool from invocation field, then namespace, then name.
         // namespace format: "mcp__<server>" (no trailing __, no tool name).
+        // v0.141.0+: also handles "mcp:server/tool" qualified name format.
         let (mcp_server, mcp_tool) = if let Some(inv) = payload.get("invocation") {
             let server = inv
                 .get("server")
@@ -555,6 +588,12 @@ impl ToolCallBuilder {
             (server, tool)
         } else if let Some(ns) = &pending.namespace {
             parse_mcp_namespace(ns, &pending.name)
+        } else if let Some((tool_type, server, tool)) = parse_namespaced_tool_name(&pending.name) {
+            if tool_type == "mcp" {
+                (Some(server), Some(tool))
+            } else {
+                parse_mcp_name(&pending.name)
+            }
         } else {
             parse_mcp_name(&pending.name)
         };
@@ -1301,6 +1340,21 @@ fn parse_mcp_name(name: &str) -> (Option<String>, Option<String>) {
     }
 }
 
+/// Parse a namespace-qualified tool name from Codex v0.141.0+ format: "type:server/tool_name".
+/// Returns (tool_type, server, tool_name) or None if the name is not in this format.
+///
+/// Examples:
+///   "mcp:my-server/my_tool"       → ("mcp", "my-server", "my_tool")
+///   "connector:plugin-1/do_thing" → ("connector", "plugin-1", "do_thing")
+fn parse_namespaced_tool_name(name: &str) -> Option<(String, String, String)> {
+    let (tool_type, rest) = name.split_once(':')?;
+    let (server, tool) = rest.split_once('/')?;
+    if tool_type.is_empty() || server.is_empty() || tool.is_empty() {
+        return None;
+    }
+    Some((tool_type.to_string(), server.to_string(), tool.to_string()))
+}
+
 fn extract_mcp_output(payload: &Value) -> Option<String> {
     let content = payload
         .get("result")
@@ -2039,5 +2093,127 @@ mod tests {
             Some("hello world\nExit code: 0\nWall time: 1.5s\n")
         );
         assert_eq!(result.status, "completed");
+    }
+
+    // --- Codex v0.141.0+ dynamic tool namespace tests ---
+
+    #[test]
+    fn parse_namespaced_tool_name_mcp_format() {
+        use super::parse_namespaced_tool_name;
+        let result = parse_namespaced_tool_name("mcp:my-server/my_tool");
+        assert_eq!(
+            result,
+            Some((
+                "mcp".to_string(),
+                "my-server".to_string(),
+                "my_tool".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_namespaced_tool_name_connector_format() {
+        use super::parse_namespaced_tool_name;
+        let result = parse_namespaced_tool_name("connector:plugin-1/do_thing");
+        assert_eq!(
+            result,
+            Some((
+                "connector".to_string(),
+                "plugin-1".to_string(),
+                "do_thing".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_namespaced_tool_name_unqualified_returns_none() {
+        use super::parse_namespaced_tool_name;
+        assert_eq!(parse_namespaced_tool_name("my_tool"), None);
+        assert_eq!(parse_namespaced_tool_name("exec_command"), None);
+        assert_eq!(parse_namespaced_tool_name("mcp__my_server"), None);
+    }
+
+    #[test]
+    fn qualified_mcp_name_in_function_call_classified_as_mcp_tool() {
+        // v0.141.0+: function_call name is "mcp:server/tool_name" (no namespace field)
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_mcp_1".to_string(),
+            "mcp:my-server/my_tool".to_string(),
+            "{}",
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_mcp_1", "result output", None);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::McpTool);
+        assert_eq!(tool.mcp_server.as_deref(), Some("my-server"));
+        assert_eq!(tool.mcp_tool.as_deref(), Some("my_tool"));
+    }
+
+    #[test]
+    fn dynamic_tool_registry_classifies_unqualified_mcp_tool() {
+        // v0.141.0+: registry from dynamic_tools in task_started lets codex-trace classify
+        // MCP tools that arrive as unqualified names with no namespace field.
+        let mut builder = ToolCallBuilder::new();
+        let mut registry = std::collections::HashMap::new();
+        registry.insert(
+            "my_tool".to_string(),
+            ("mcp".to_string(), "my-server".to_string()),
+        );
+        builder.set_dynamic_tool_registry(registry);
+
+        builder.add_function_call(
+            "call_mcp_2".to_string(),
+            "my_tool".to_string(),
+            "{}",
+            None,
+            None,
+            None,
+        );
+        builder.add_function_call_output("call_mcp_2", "result output", None);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tool = &builder.finalized[0];
+        assert_eq!(tool.kind, ToolKind::McpTool);
+        assert_eq!(tool.mcp_server.as_deref(), Some("my-server"));
+        assert_eq!(tool.mcp_tool.as_deref(), Some("my_tool"));
+    }
+
+    #[test]
+    fn dynamic_tool_registry_does_not_affect_builtin_tool_classification() {
+        // Registry entries must not override built-in tool classifications.
+        let mut builder = ToolCallBuilder::new();
+        let mut registry = std::collections::HashMap::new();
+        // Hypothetical conflict: someone registers exec_command as an MCP tool
+        registry.insert(
+            "exec_command".to_string(),
+            ("mcp".to_string(), "some-server".to_string()),
+        );
+        builder.set_dynamic_tool_registry(registry);
+
+        builder.add_function_call(
+            "call_exec".to_string(),
+            "exec_command".to_string(),
+            r#"{"cmd":"echo hi","workdir":"/tmp"}"#,
+            None,
+            None,
+            None,
+        );
+        let payload = json!({
+            "call_id": "call_exec",
+            "aggregated_output": "hi\n",
+            "exit_code": 0,
+            "status": "completed",
+            "duration": {"secs": 0, "nanos": 10_000_000u64}
+        });
+        builder.finalize_exec("exec_command_end", &payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        // Built-in classification must win — exec_command via exec_command_end → ExecCommand
+        assert_eq!(builder.finalized[0].kind, ToolKind::ExecCommand);
     }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -320,9 +320,15 @@ fn handle_event_msg(
             });
             turns.insert(turn_id.clone(), turn);
             *current_turn_id = Some(turn_id.clone());
-            tool_builders
+            let builder = tool_builders
                 .entry(turn_id)
                 .or_insert_with(ToolCallBuilder::new);
+            // Codex v0.141.0+ (PRs #27365, #27371): parse dynamic_tools and build a tool
+            // registry so namespaced MCP/connector tools can be classified correctly.
+            let registry = parse_dynamic_tools(payload);
+            if !registry.is_empty() {
+                builder.set_dynamic_tool_registry(registry);
+            }
         }
 
         "user_message" => {
@@ -1114,6 +1120,54 @@ fn str_field(v: &Value, key: &str) -> String {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()
+}
+
+/// Parse the `dynamic_tools` field from a `task_started` payload (Codex v0.141.0+).
+///
+/// Returns a registry mapping unqualified tool names to (tool_type, server).
+/// Handles two formats:
+///   {"name": "my_tool", "namespace": "mcp:my-server"}  → key="my_tool", ("mcp","my-server")
+///   {"name": "mcp:my-server/my_tool"}                  → key="my_tool", ("mcp","my-server")
+fn parse_dynamic_tools(payload: &Value) -> HashMap<String, (String, String)> {
+    let Some(tools) = payload.get("dynamic_tools").and_then(|v| v.as_array()) else {
+        return HashMap::new();
+    };
+    let mut registry = HashMap::new();
+    for item in tools {
+        let Some(name) = item
+            .get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue;
+        };
+        if let Some(ns) = item
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            // Explicit namespace field: "mcp:server" or "connector:plugin"
+            if let Some((tool_type, server)) = ns.split_once(':') {
+                if !tool_type.is_empty() && !server.is_empty() {
+                    registry.insert(
+                        name.to_string(),
+                        (tool_type.to_string(), server.to_string()),
+                    );
+                }
+            }
+        } else if let Some((tool_type, rest)) = name.split_once(':') {
+            // Qualified name format: "mcp:server/tool_name"
+            if let Some((server, tool)) = rest.split_once('/') {
+                if !tool_type.is_empty() && !server.is_empty() && !tool.is_empty() {
+                    registry.insert(
+                        tool.to_string(),
+                        (tool_type.to_string(), server.to_string()),
+                    );
+                }
+            }
+        }
+    }
+    registry
 }
 
 fn spawn_from_function_call_output(
@@ -3281,5 +3335,112 @@ mod tests {
         assert!(!tool.arguments.is_null());
         assert!(tool.arguments.get("options").is_some());
         assert_eq!(tool.output.as_deref(), Some("submitted"));
+    }
+
+    // --- Codex v0.141.0+ dynamic tool namespace tests (PRs #27365, #27371) ---
+
+    #[test]
+    fn parse_dynamic_tools_with_explicit_namespace_field() {
+        use super::parse_dynamic_tools;
+        use serde_json::json;
+        let payload = json!({
+            "type": "task_started",
+            "turn_id": "turn-1",
+            "dynamic_tools": [
+                {"name": "my_tool", "namespace": "mcp:my-server"},
+                {"name": "other_tool", "namespace": "connector:plugin-1"}
+            ]
+        });
+        let registry = parse_dynamic_tools(&payload);
+        assert_eq!(
+            registry.get("my_tool"),
+            Some(&("mcp".to_string(), "my-server".to_string()))
+        );
+        assert_eq!(
+            registry.get("other_tool"),
+            Some(&("connector".to_string(), "plugin-1".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_dynamic_tools_with_qualified_name_in_name_field() {
+        use super::parse_dynamic_tools;
+        use serde_json::json;
+        let payload = json!({
+            "type": "task_started",
+            "turn_id": "turn-1",
+            "dynamic_tools": [
+                {"name": "mcp:my-server/my_tool"}
+            ]
+        });
+        let registry = parse_dynamic_tools(&payload);
+        // Key is the unqualified tool name extracted from the qualified name
+        assert_eq!(
+            registry.get("my_tool"),
+            Some(&("mcp".to_string(), "my-server".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_dynamic_tools_absent_returns_empty() {
+        use super::parse_dynamic_tools;
+        use serde_json::json;
+        let payload = json!({"type": "task_started", "turn_id": "turn-1"});
+        assert!(parse_dynamic_tools(&payload).is_empty());
+    }
+
+    #[test]
+    fn v0141_task_started_dynamic_tools_classifies_mcp_tool_via_registry() {
+        // v0.141.0+: task_started has dynamic_tools; function_call has unqualified name.
+        // Registry lookup must classify the tool as McpTool.
+        let lines = [
+            r#"{"timestamp":"2026-06-18T10:00:00Z","type":"session_meta","payload":{"session_id":"v0141-dyn","timestamp":"2026-06-18T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1","dynamic_tools":[{"name":"my_tool","namespace":"mcp:my-server"}]}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:02Z","type":"response_item","payload":{"type":"function_call","call_id":"call-dyn-1","name":"my_tool","arguments":"{}"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-dyn-1","output":"ok"}}"#,
+            r#"{"timestamp":"2026-06-18T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750240804.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(
+            tool.kind,
+            crate::parser::toolcall::ToolKind::McpTool,
+            "tool should be classified as McpTool via dynamic_tools registry"
+        );
+        assert_eq!(tool.mcp_server.as_deref(), Some("my-server"));
+        assert_eq!(tool.mcp_tool.as_deref(), Some("my_tool"));
+    }
+
+    #[test]
+    fn v0141_task_started_dynamic_tools_classifies_mcp_tool_via_qualified_name() {
+        // v0.141.0+: function_call name is "mcp:server/tool" (namespace-qualified).
+        let lines = [
+            r#"{"timestamp":"2026-06-18T10:01:00Z","type":"session_meta","payload":{"session_id":"v0141-qual","timestamp":"2026-06-18T10:01:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:02Z","type":"response_item","payload":{"type":"function_call","call_id":"call-qual-1","name":"mcp:my-server/my_tool","arguments":"{}"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-qual-1","output":"done"}}"#,
+            r#"{"timestamp":"2026-06-18T10:01:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-2","completed_at":1750240864.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tool = &turns[0].tool_calls[0];
+        assert_eq!(
+            tool.kind,
+            crate::parser::toolcall::ToolKind::McpTool,
+            "namespace-qualified tool name must be classified as McpTool"
+        );
+        assert_eq!(tool.mcp_server.as_deref(), Some("my-server"));
+        assert_eq!(tool.mcp_tool.as_deref(), Some("my_tool"));
     }
 }


### PR DESCRIPTION
## Summary

Adds compatibility for Codex v0.141.0 (PRs #27365, #27371), which introduced explicit namespace fields for dynamic tools (MCP, connector, plugin tools) in `ThreadStart`/`task_started` events.

## Background

Codex v0.141.0 changed how dynamic tools are represented in session transcripts:

1. The `task_started` event payload now includes a `dynamic_tools` array listing tools with explicit namespace info. Each entry is either:
   - `{"name": "my_tool", "namespace": "mcp:my-server"}` — explicit namespace field
   - `{"name": "mcp:my-server/my_tool"}` — qualified name format

2. `function_call` items may now use namespace-qualified tool names (`mcp:server/tool_name`) instead of bare names.

Without this fix, MCP/connector tools from v0.141.0+ sessions were classified as `ToolKind::Unknown` because the existing lookup logic only handled unqualified names.

## Changes

**`src-tauri/src/parser/turn.rs`**
- Add `parse_dynamic_tools()`: parses the `dynamic_tools` array from `task_started` payloads, returning a registry mapping unqualified tool names to `(tool_type, server)`. Handles both explicit-namespace and qualified-name formats.
- Wire `parse_dynamic_tools()` into `handle_event_msg` so `ToolCallBuilder` receives the registry on each `task_started` event.

**`src-tauri/src/parser/toolcall.rs`**
- Add `dynamic_tool_registry: HashMap<String, (String, String)>` field to `ToolCallBuilder`.
- Add `set_dynamic_tool_registry()` setter, called from `turn.rs` after `task_started`.
- Add `parse_namespaced_tool_name()`: parses `"type:server/tool_name"` format into `(tool_type, server, tool)`.
- Update `add_function_call_output` fallback branch: first try `parse_namespaced_tool_name`, then registry lookup, before falling back to `ToolKind::Unknown`.
- Update `finalize_mcp` MCP server/tool extraction: after namespace field check, try `parse_namespaced_tool_name` before `parse_mcp_name`.

## Test Coverage

11 new tests added across both files:
- `parse_namespaced_tool_name_mcp_format` / `_connector_format` / `_unqualified_returns_none`
- `qualified_mcp_name_in_function_call_classified_as_mcp_tool`
- `dynamic_tool_registry_classifies_unqualified_mcp_tool`
- `parse_dynamic_tools_with_explicit_namespace_field`
- `parse_dynamic_tools_with_qualified_name_in_name_field`
- `parse_dynamic_tools_absent_returns_empty`
- `v0141_task_started_dynamic_tools_classifies_mcp_tool_via_registry`
- `v0141_task_started_dynamic_tools_classifies_mcp_tool_via_qualified_name`
- `parse_namespaced_tool_name_empty_parts_returns_none`

## Test Results

All 272 Rust unit tests pass. All 135 frontend tests pass. Clippy clean.

Fixes #146
