### PR TITLE
[#160]: fix MAv2 agent_message typed envelope parsing (Codex v0.142.0)

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1182,6 +1182,56 @@ mod tests {
         assert_eq!(meta.payload["id"], "v0140-session");
     }
 
+    // Codex v0.142.0 (PR #28368): multi-agent v2 inter-agent messages now use typed
+    // envelopes. The `agent_message` event_msg payload's `message` field changed from a
+    // plain string to a typed object `{"type": "<kind>", "content": "..."}`. The RawEntry
+    // parser must pass the payload through without error — payload extraction is unaffected
+    // because RawEntry is Value-based. The type-aware decoding happens in turn.rs.
+
+    #[test]
+    fn v0142_agent_message_with_typed_envelope_parses_as_event_msg() {
+        let line = r#"{"timestamp":"2026-06-22T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"text","content":"Hello from the subagent."},"phase":"main"}}"#;
+        let e = RawEntry::parse(line).expect("typed-envelope agent_message must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(event_msg_type(&e.payload), Some("agent_message"));
+        // The typed envelope is accessible as a Value for downstream decoding.
+        let msg = &e.payload["message"];
+        assert!(msg.is_object(), "message must be an object in v0.142.0+");
+        assert_eq!(msg["type"], "text");
+        assert_eq!(msg["content"], "Hello from the subagent.");
+    }
+
+    #[test]
+    fn v0142_all_standard_entry_types_parse_correctly() {
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"v0142-session","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.142.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"text","content":"Processing."},"phase":"commentary"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593605.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.142.0");
+        assert_eq!(meta.payload["id"], "v0142-session");
+        // Verify the typed-envelope agent_message payload is accessible.
+        let agent_msg = RawEntry::parse(lines[4]).unwrap();
+        assert_eq!(agent_msg.payload["message"]["type"], "text");
+        assert_eq!(agent_msg.payload["message"]["content"], "Processing.");
+    }
+
     #[test]
     fn v0140_session_meta_with_secret_auth_storage_configuration_does_not_panic() {
         // session_meta may carry the new secret_auth_storage_configuration field introduced

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -365,9 +365,8 @@ fn handle_event_msg(
                 if let Some(turn) = turns.get_mut(tid) {
                     let text = payload
                         .get("message")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                        .map(extract_message_text)
+                        .unwrap_or_default();
                     if !text.is_empty() {
                         let phase = payload
                             .get("phase")
@@ -1139,6 +1138,40 @@ fn str_field(v: &Value, key: &str) -> String {
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()
+}
+
+/// Extract displayable text from an `agent_message` payload's `message` field.
+///
+/// Codex v0.142.0 (PR #28368) changed multi-agent v2 inter-agent messages from
+/// plain strings to typed envelopes `{"type": "<kind>", "content": "..."}`.
+/// This function handles both formats so old and new sessions parse correctly.
+fn extract_message_text(message: &Value) -> String {
+    // Legacy format (pre-v0.142.0): message is a plain string.
+    if let Some(s) = message.as_str() {
+        return s.to_string();
+    }
+
+    // v0.142.0+ typed envelope: dispatch on the "type" discriminant.
+    if let Some(envelope_type) = message.get("type").and_then(|t| t.as_str()) {
+        match envelope_type {
+            // "text" envelope: content is in the "content" field.
+            "text" => {
+                return message
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+            }
+            // Other envelope types: try "content" as a best-effort fallback.
+            _ => {
+                if let Some(content) = message.get("content").and_then(|v| v.as_str()) {
+                    return content.to_string();
+                }
+            }
+        }
+    }
+
+    String::new()
 }
 
 /// Parse the `dynamic_tools` field from a `task_started` payload (Codex v0.141.0+).
@@ -3581,5 +3614,118 @@ mod tests {
         assert_eq!(turn.agent_messages.len(), 1);
         assert_eq!(turn.agent_messages[0].text, "Done.");
         assert_eq!(turn.status, super::TurnStatus::Complete);
+    }
+
+    // Codex v0.142.0 (PR #28368): multi-agent v2 inter-agent messages now use typed
+    // envelopes instead of plain string payloads. The `message` field in `agent_message`
+    // events is now an object `{"type": "<kind>", "content": "..."}` rather than a raw
+    // string. The parser must read the type discriminant and dispatch to the correct decoder.
+
+    #[test]
+    fn v0142_agent_message_with_typed_text_envelope_extracts_content() {
+        // v0.142.0 typed envelope: {"type": "text", "content": "..."}.
+        // The parser must read the type discriminant and return the content string.
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"v0142-session","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.142.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"text","content":"Hello from the subagent."},"phase":"main"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.agent_messages.len(), 1);
+        assert_eq!(turn.agent_messages[0].text, "Hello from the subagent.");
+        assert_eq!(turn.agent_messages[0].phase.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn v0142_agent_message_plain_string_still_parses_correctly() {
+        // Pre-v0.142.0 sessions with a plain-string `message` must continue to parse.
+        // The backward-compatible path must not break when upgrading.
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"pre-v0142","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.141.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"Plain text message.","phase":"main"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].agent_messages.len(), 1);
+        assert_eq!(turns[0].agent_messages[0].text, "Plain text message.");
+    }
+
+    #[test]
+    fn v0142_agent_message_typed_envelope_final_answer_phase_sets_final_answer() {
+        // Typed envelope with phase "final_answer" must populate turn.final_answer.
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"v0142-final","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.142.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"text","content":"The answer is 42."},"phase":"final_answer"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.agent_messages.len(), 1);
+        assert_eq!(turn.agent_messages[0].text, "The answer is 42.");
+        assert_eq!(turn.final_answer.as_deref(), Some("The answer is 42."));
+    }
+
+    #[test]
+    fn v0142_agent_message_unknown_envelope_type_falls_back_to_content_field() {
+        // Unknown envelope types must fall back to the "content" field rather than silently
+        // dropping the message. This ensures forward-compatibility with future envelope types.
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"v0142-unk","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.142.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"rich_text","content":"Rendered output."},"phase":"commentary"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].agent_messages.len(), 1);
+        assert_eq!(turns[0].agent_messages[0].text, "Rendered output.");
+    }
+
+    #[test]
+    fn v0142_all_standard_entry_types_parse_correctly() {
+        // Regression guard: all four standard JSONL entry types from a v0.142.0 session
+        // must parse correctly. Includes a typed-envelope agent_message.
+        let lines = [
+            r#"{"timestamp":"2026-06-22T10:00:00Z","type":"session_meta","payload":{"id":"v0142-full","timestamp":"2026-06-22T10:00:00Z","cwd":"/project","cli_version":"0.142.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":{"type":"text","content":"Processing your request."},"phase":"commentary"}}"#,
+            r#"{"timestamp":"2026-06-22T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1750593605.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+        assert_eq!(turn.agent_messages.len(), 1);
+        assert_eq!(turn.agent_messages[0].text, "Processing your request.");
+        assert_eq!(turn.model.as_deref(), Some("gpt-5"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #160

Codex v0.142.0 (PR #28368) changed how multi-agent v2 inter-agent messages are rendered: the `message` field in `agent_message` events changed from a plain string to a typed envelope object `{"type": "<kind>", "content": "..."}`.

The previous parser used `.and_then(|v| v.as_str())` which silently returned an empty string for envelope objects, causing all v0.142.0+ MAv2 agent messages to be silently dropped from session traces.

## Changes

**`src-tauri/src/parser/turn.rs`**
- Added `extract_message_text(message: &Value) -> String` helper that reads the `type` discriminant from the envelope and dispatches to type-specific decoding:
  - Plain string (pre-v0.142.0): returned as-is for backward compatibility
  - `"text"` envelope: reads `.content` field
  - Other envelope types: falls back to `.content` field for forward compatibility with future types
- Updated the `agent_message` event handler to use the new helper

**`src-tauri/src/parser/entry.rs`**
- Added `v0142_agent_message_with_typed_envelope_parses_as_event_msg` test
- Added `v0142_all_standard_entry_types_parse_correctly` regression guard

**`src-tauri/src/parser/turn.rs` (tests)**
- `v0142_agent_message_with_typed_text_envelope_extracts_content`
- `v0142_agent_message_plain_string_still_parses_correctly` (backward compat)
- `v0142_agent_message_typed_envelope_final_answer_phase_sets_final_answer`
- `v0142_agent_message_unknown_envelope_type_falls_back_to_content_field`
- `v0142_all_standard_entry_types_parse_correctly`

## Verification

- All 301 Rust unit tests pass (`cargo test --lib`)
- All 143 frontend tests pass (`npx vitest run`)
- `cargo clippy -- -D warnings`: clean
- `cargo fmt`: no changes
