### PR TITLE
fix(parser): rename duplicate v0142 test to unbreak CI

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1467,7 +1467,7 @@ mod tests {
     }
 
     #[test]
-    fn v0142_all_standard_entry_types_parse_correctly() {
+    fn v0142_2_all_standard_entry_types_parse_correctly_with_metadata_turn_id() {
         // Regression guard: all standard entry types from a v0.142.2 session must parse.
         // response_items carry metadata.turn_id; other entry types are unchanged.
         let lines = [


### PR DESCRIPTION
## Problem

CI has been red on `main` since #166 landed. The error:

```
error[E0428]: the name `v0142_all_standard_entry_types_parse_correctly` is defined multiple times
    --> src/parser/entry.rs:1470:5
     |
1273 |     fn v0142_all_standard_entry_types_parse_correctly() {
     |     --- previous definition of the value `v0142_all_standard_entry_types_parse_correctly` here
...
1470 |     fn v0142_all_standard_entry_types_parse_correctly() {
     |     ^^^ `v0142_all_standard_entry_types_parse_correctly` redefined here
```

## Cause

PR #166 (metadata.turn_id) and PR #168 (UUIDv7 + lineage_id) each added a `v0142_all_standard_entry_types_parse_correctly` test function to `src-tauri/src/parser/entry.rs`'s `mod tests`. Each PR's branch compiled fine in isolation, but the squash-merges produced a duplicate at the same scope on `main`.

## Fix

Rename the #166 test (covers `metadata.turn_id`) to
`v0142_2_all_standard_entry_types_parse_correctly_with_metadata_turn_id`
— the v0.142.0 standard-types test from #168 (UUIDv7 + lineage_id) keeps the shorter name as the primary v0.142.0 regression guard.

## Verification

```
cargo test --lib parser::
test result: ok. 303 passed; 0 failed; 0 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUrcWnBho9wCV8PZDb6CKi)_