### PR TITLE
Add terminal UI (--tui) mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 npm run dev              # Vite dev server
 npm run tauri dev        # Full Tauri desktop app
 npm run dev:web          # Web mode (opens browser)
+npm run dev:tui          # Terminal UI (cargo run --bin codex-trace -- --tui)
 
 # Lint
 npx oxlint              # JS/TS lint

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ npm install
 
 npm run tauri dev        # desktop app with hot reload
 npm run dev:web          # web mode (opens browser)
+npm run dev:tui          # terminal UI (builds and runs the Rust binary directly)
 ```
 
 ### Run in Docker
@@ -121,14 +122,16 @@ Browses the same `~/.codex/sessions/` data as the desktop and web UI, entirely i
 | Screen         | Keys           | Action                                           |
 | -------------- | -------------- | ------------------------------------------------ |
 | Session Picker | `j` / `k`      | Move selection                                   |
-| Session Picker | `Enter`        | Open a session, or expand/collapse a date group  |
+| Session Picker | `Enter`        | Open a session, or expand/collapse a group       |
 | Session Picker | `/`            | Search sessions (`Esc` clears, `Enter` keeps it) |
+| Session Picker | `p`            | Toggle grouping: by date / by project (cwd)      |
 | Session Picker | `r`            | Rescan the sessions directory                    |
 | Session Detail | `j` / `k`      | Move selection (list) or scroll (detail)         |
 | Session Detail | `Tab`          | Expand/collapse a tool call inline               |
 | Session Detail | `e` / `c`      | Expand / collapse all tool calls                 |
 | Session Detail | `Enter`        | Open full detail, or drill into a spawned agent  |
 | Session Detail | `h` / `l`      | Switch Request / Response panel in detail view   |
+| Session Detail | `t`            | Team board — roster of every spawned agent       |
 | Session Detail | `r`            | Reload the session from disk                     |
 | Session Detail | `Esc` / `q`    | Back to the list, or back to the picker          |
 | All screens    | `?`            | Toggle keybinding help                           |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use Codex Trace when you want to:
 - **Collaboration tracking** — links orchestrator and worker sessions
 - **Token visibility** — shows token counts where available in Codex CLI session data
 - **Multiple Codex JSONL formats** — supports new (≥0.44), mid, and oldest (2025/08) session metadata formats
-- **Desktop and web modes** — run as a native desktop app or browser-based viewer
+- **Desktop, web, and terminal modes** — run as a native desktop app, browser-based viewer, or in-terminal TUI
 - **Docker support** — run headless web mode on port 1422
 
 ## Why use Codex Trace?
@@ -68,6 +68,7 @@ cd codex-trace
 #   macOS:  open -a "Codex Trace"   (or from Launchpad/Applications)
 #   Linux:  codex-trace
 codex-trace --web         # web mode (opens browser)
+codex-trace --tui         # terminal UI (SSH-friendly, no browser/GUI needed)
 ```
 
 ### Run from source without installing
@@ -108,6 +109,30 @@ Codex Trace reads session files from this default path:
 ```
 
 The sidebar reflects the folder structure exactly. Date groups in `YYYY/MM/DD` format can be collapsed and expanded, with Codex CLI sessions shown underneath.
+
+## Terminal UI
+
+```bash
+codex-trace --tui
+```
+
+Browses the same `~/.codex/sessions/` data as the desktop and web UI, entirely in the terminal — useful over SSH or when no display is available. Sessions from an active run are re-read automatically while the session is open.
+
+| Screen         | Keys           | Action                                           |
+| -------------- | -------------- | ------------------------------------------------ |
+| Session Picker | `j` / `k`      | Move selection                                   |
+| Session Picker | `Enter`        | Open a session, or expand/collapse a date group  |
+| Session Picker | `/`            | Search sessions (`Esc` clears, `Enter` keeps it) |
+| Session Picker | `r`            | Rescan the sessions directory                    |
+| Session Detail | `j` / `k`      | Move selection (list) or scroll (detail)         |
+| Session Detail | `Tab`          | Expand/collapse a tool call inline               |
+| Session Detail | `e` / `c`      | Expand / collapse all tool calls                 |
+| Session Detail | `Enter`        | Open full detail, or drill into a spawned agent  |
+| Session Detail | `h` / `l`      | Switch Request / Response panel in detail view   |
+| Session Detail | `r`            | Reload the session from disk                     |
+| Session Detail | `Esc` / `q`    | Back to the list, or back to the picker          |
+| All screens    | `?`            | Toggle keybinding help                           |
+| All screens    | `q` / `Ctrl+C` | Quit                                             |
 
 ## Configuration
 

--- a/bin/codex-trace.mjs
+++ b/bin/codex-trace.mjs
@@ -10,7 +10,7 @@ const binDir = dirname(fileURLToPath(import.meta.url));
 const root = resolve(binDir, "..");
 
 const args = process.argv.slice(2);
-const mode = args.find((a) => ["--app", "--web"].includes(a)) ?? "--app";
+const mode = args.find((a) => ["--app", "--web", "--tui"].includes(a)) ?? "--app";
 const noOpen = args.includes("--no-open");
 
 function run(cmd, cmdArgs, opts = {}) {
@@ -66,6 +66,23 @@ function openBrowser(url) {
 switch (mode) {
   case "--app":
     run("npx", ["tauri", "dev"]);
+    break;
+
+  case "--tui":
+    // The TUI is a native terminal app (crossterm raw mode) that reads
+    // session files directly — no Vite/Tauri dev server or backend needed,
+    // so this builds and runs the Rust binary straight through cargo rather
+    // than `npx tauri dev`.
+    run("cargo", [
+      "run",
+      "--quiet",
+      "--manifest-path",
+      "src-tauri/Cargo.toml",
+      "--bin",
+      "codex-trace",
+      "--",
+      "--tui",
+    ]);
     break;
 
   case "--web": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "dev:web": "tauri dev -- -- --web",
+    "dev:tui": "cargo run --manifest-path src-tauri/Cargo.toml --bin codex-trace -- --tui",
     "lint": "oxlint && cargo clippy --manifest-path src-tauri/Cargo.toml",
     "fmt": "oxfmt && cargo fmt --manifest-path src-tauri/Cargo.toml",
     "fmt:check": "oxfmt --check && cargo fmt --manifest-path src-tauri/Cargo.toml --check",

--- a/script/install.sh
+++ b/script/install.sh
@@ -45,6 +45,7 @@ if [ "$OS" = "Darwin" ]; then
   echo "Installed! Launch the desktop app from Launchpad/Applications, or:"
   echo "  open -a \"Codex Trace\"   # desktop app"
   echo "  codex-trace --web        # web mode (opens browser)"
+  echo "  codex-trace --tui        # terminal UI (SSH-friendly, no browser/GUI needed)"
 else
   echo "==> Building frontend..."
   npm run build
@@ -59,4 +60,5 @@ else
   echo "Installed! Run:"
   echo "  codex-trace          # desktop app (default)"
   echo "  codex-trace --web    # web mode (opens browser)"
+  echo "  codex-trace --tui    # terminal UI (SSH-friendly, no browser/GUI needed)"
 fi

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,6 +52,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "async-broadcast"
@@ -202,6 +217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,12 +303,27 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -300,9 +339,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -366,6 +405,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,7 +437,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -454,6 +499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +581,7 @@ dependencies = [
  "dirs",
  "indexmap 2.14.0",
  "notify",
+ "ratatui",
  "serde",
  "serde_json",
  "tauri",
@@ -548,6 +609,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +636,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -594,7 +678,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -607,7 +691,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "libc",
 ]
@@ -631,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +736,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +770,16 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -757,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,7 +905,7 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -794,6 +927,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -837,7 +971,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -878,12 +1012,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser 0.36.0",
  "foldhash 0.2.0",
  "html5ever 0.38.0",
@@ -942,6 +1085,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embed-resource"
@@ -1018,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1195,22 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -1064,10 +1238,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1439,7 +1636,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1566,9 +1763,25 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1884,6 +2097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,7 +2120,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -1910,6 +2132,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1935,6 +2170,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2055,12 +2299,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -2096,6 +2351,18 @@ dependencies = [
  "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2153,12 +2420,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2172,6 +2454,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2189,10 +2477,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2249,6 +2556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +2585,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2322,7 +2641,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -2347,10 +2666,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify"
@@ -2358,7 +2700,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2376,7 +2718,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2384,6 +2726,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -2417,6 +2770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,7 +2794,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -2445,7 +2807,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2466,7 +2828,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -2477,7 +2839,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2510,7 +2872,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2537,7 +2899,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -2550,7 +2912,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2561,7 +2923,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2573,7 +2935,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -2604,7 +2966,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2637,6 +2999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +3015,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2713,6 +3108,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,6 +3176,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2834,6 +3273,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2940,7 +3392,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2960,6 +3412,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3181,6 +3639,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
+ "compact_str",
+ "critical-section",
+ "hashbrown 0.17.0",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.0",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,7 +3751,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3310,7 +3869,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3419,7 +3978,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cssparser 0.36.0",
  "derive_more 2.1.1",
  "log",
@@ -3650,6 +4209,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +4334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3807,6 +4393,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "swift-rs"
@@ -3880,7 +4487,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -4259,6 +4866,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2",
+ "signal-hook",
+ "siphasher 1.0.2",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4306,7 +4989,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4534,7 +5219,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -4552,7 +5237,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4656,6 +5341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,6 +5417,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4769,11 +5477,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -4810,6 +5525,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
 ]
 
 [[package]]
@@ -4957,7 +5681,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -5063,6 +5787,78 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -5591,7 +6387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 indexmap = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 zstd = "0.13"
+ratatui = "0.30"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod http_api;
 mod parser;
 mod settings;
 mod state;
+mod tui;
 mod watcher;
 
 use std::sync::Arc;
@@ -15,8 +16,28 @@ pub fn run() {
     let args: Vec<String> = std::env::args().collect();
     let web_only = args.iter().any(|a| a == "--web");
     let headless = args.iter().any(|a| a == "--headless");
+    let tui_mode = args.iter().any(|a| a == "--tui");
     let no_open = args.iter().any(|a| a == "--no-open");
-    let desktop = !web_only && !headless;
+    let desktop = !web_only && !headless && !tui_mode;
+
+    // TUI mode: skip Tauri/WebKit and the HTTP server entirely — a terminal-only
+    // session browser for use over SSH or in place of the desktop/web UI.
+    if tui_mode {
+        let settings = settings::load_settings();
+        let sessions_dir =
+            match parser::session::resolve_sessions_dir(settings.sessions_dir.as_deref()) {
+                Ok(dir) => dir,
+                Err(e) => {
+                    eprintln!("codex-trace --tui: {e}");
+                    std::process::exit(1);
+                }
+            };
+        if let Err(e) = tui::run_tui(sessions_dir) {
+            eprintln!("codex-trace --tui: {e}");
+            std::process::exit(1);
+        }
+        return;
+    }
 
     // Headless mode: skip Tauri/WebKit entirely — run only the HTTP server.
     // This eliminates the WebKitWebProcess + WebKitNetworkProcess that Tauri

--- a/src-tauri/src/parser/diff.rs
+++ b/src-tauri/src/parser/diff.rs
@@ -1,0 +1,395 @@
+//! Structural line + word diff, ported from `shared/diff.ts` so the Rust TUI
+//! renders the same red/green, word-highlighted diffs as the web/desktop
+//! frontend for `apply_patch` tool calls (see `patch.rs`).
+//!
+//! Produces a line-level unified diff that PRESERVES unchanged context lines,
+//! and for each pair of changed lines computes intra-line WORD-level change
+//! ranges (LCS pairing + a similarity gate so dissimilar lines aren't falsely
+//! aligned). Keep in sync with `shared/diff.ts`.
+
+/// Beyond this many DP cells the O(n*m) line LCS is skipped in favour of a
+/// plain "all removed then all added" rendering. Edit payloads are small in
+/// practice.
+const MAX_LCS_CELLS: usize = 40_000;
+
+/// Minimum fraction of shared non-whitespace tokens for two lines to be
+/// treated as an edit of each other (and thus word-diffed rather than shown
+/// as wholly removed/added).
+const WORD_SIMILARITY_THRESHOLD: f64 = 0.3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffLineKind {
+    Context,
+    Removed,
+    Added,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffSegment {
+    pub text: String,
+    /// True when this span differs from the paired line (word-level highlight).
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffLine {
+    pub kind: DiffLineKind,
+    pub segments: Vec<DiffSegment>,
+}
+
+/// A line classified as context/removed/added, before word-level segmenting.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LineOp {
+    pub kind: DiffLineKind,
+    pub text: String,
+}
+
+/// Words (letters/digits/underscore), whitespace runs, and punctuation runs.
+pub fn tokenize(s: &str) -> Vec<String> {
+    #[derive(PartialEq)]
+    enum Class {
+        Word,
+        Whitespace,
+        Punct,
+    }
+    fn classify(c: char) -> Class {
+        if c.is_alphanumeric() || c == '_' {
+            Class::Word
+        } else if c.is_whitespace() {
+            Class::Whitespace
+        } else {
+            Class::Punct
+        }
+    }
+
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut current_class: Option<Class> = None;
+    for c in s.chars() {
+        let class = classify(c);
+        match &current_class {
+            Some(cc) if *cc == class => current.push(c),
+            _ => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+                current.push(c);
+                current_class = Some(class);
+            }
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn is_whitespace(tok: &str) -> bool {
+    tok.trim().is_empty()
+}
+
+/// Marks which elements of `a` / `b` participate in their longest common
+/// subsequence (by equality). O(n*m) time and space.
+fn lcs_matched(a: &[String], b: &[String]) -> (Vec<bool>, Vec<bool>) {
+    let n = a.len();
+    let m = b.len();
+    let mut a_matched = vec![false; n];
+    let mut b_matched = vec![false; m];
+    if n == 0 || m == 0 {
+        return (a_matched, b_matched);
+    }
+
+    let mut dp = vec![vec![0u32; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if a[i] == b[j] {
+                dp[i + 1][j + 1] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            a_matched[i] = true;
+            b_matched[j] = true;
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    (a_matched, b_matched)
+}
+
+/// Merge adjacent tokens with the same changed flag. Whitespace is never
+/// flagged changed, so leading/trailing spaces aren't highlighted on their own.
+fn build_segments(tokens: &[String], matched: &[bool]) -> Vec<DiffSegment> {
+    let mut segs: Vec<DiffSegment> = Vec::new();
+    for (i, tok) in tokens.iter().enumerate() {
+        let changed = !matched[i] && !is_whitespace(tok);
+        match segs.last_mut() {
+            Some(last) if last.changed == changed => last.text.push_str(tok),
+            _ => segs.push(DiffSegment {
+                text: tok.clone(),
+                changed,
+            }),
+        }
+    }
+    segs
+}
+
+/// Word-level diff of two lines. Returns `None` when the lines are too
+/// dissimilar to be considered a single edit (caller then shows them wholly
+/// removed/added).
+pub fn word_diff(old_line: &str, new_line: &str) -> Option<(Vec<DiffSegment>, Vec<DiffSegment>)> {
+    let a = tokenize(old_line);
+    let b = tokenize(new_line);
+    let (a_matched, b_matched) = lcs_matched(&a, &b);
+
+    let a_non_ws = a.iter().filter(|t| !is_whitespace(t)).count();
+    let b_non_ws = b.iter().filter(|t| !is_whitespace(t)).count();
+    let denom = a_non_ws.max(b_non_ws);
+    if denom == 0 {
+        return None;
+    }
+
+    let common_non_ws = a
+        .iter()
+        .enumerate()
+        .filter(|(i, t)| a_matched[*i] && !is_whitespace(t))
+        .count();
+    if (common_non_ws as f64) / (denom as f64) < WORD_SIMILARITY_THRESHOLD {
+        return None;
+    }
+
+    Some((
+        build_segments(&a, &a_matched),
+        build_segments(&b, &b_matched),
+    ))
+}
+
+fn line_diff_ops(old_lines: &[String], new_lines: &[String]) -> Vec<LineOp> {
+    let n = old_lines.len();
+    let m = new_lines.len();
+    if n.saturating_mul(m) > MAX_LCS_CELLS {
+        return old_lines
+            .iter()
+            .map(|t| LineOp {
+                kind: DiffLineKind::Removed,
+                text: t.clone(),
+            })
+            .chain(new_lines.iter().map(|t| LineOp {
+                kind: DiffLineKind::Added,
+                text: t.clone(),
+            }))
+            .collect();
+    }
+
+    let mut dp = vec![vec![0u32; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if old_lines[i] == new_lines[j] {
+                dp[i + 1][j + 1] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+
+    let mut ops = Vec::new();
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < n && j < m {
+        if old_lines[i] == new_lines[j] {
+            ops.push(LineOp {
+                kind: DiffLineKind::Context,
+                text: old_lines[i].clone(),
+            });
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            ops.push(LineOp {
+                kind: DiffLineKind::Removed,
+                text: old_lines[i].clone(),
+            });
+            i += 1;
+        } else {
+            ops.push(LineOp {
+                kind: DiffLineKind::Added,
+                text: new_lines[j].clone(),
+            });
+            j += 1;
+        }
+    }
+    while i < n {
+        ops.push(LineOp {
+            kind: DiffLineKind::Removed,
+            text: old_lines[i].clone(),
+        });
+        i += 1;
+    }
+    while j < m {
+        ops.push(LineOp {
+            kind: DiffLineKind::Added,
+            text: new_lines[j].clone(),
+        });
+        j += 1;
+    }
+    ops
+}
+
+/// Within each maximal run of changes, emit all removed lines before all
+/// added lines so `removed[i]` can be paired with `added[i]` for word-diffing.
+pub fn group_runs(ops: Vec<LineOp>) -> Vec<LineOp> {
+    let mut out = Vec::with_capacity(ops.len());
+    let mut k = 0;
+    while k < ops.len() {
+        if ops[k].kind == DiffLineKind::Context {
+            out.push(ops[k].clone());
+            k += 1;
+            continue;
+        }
+        let mut removed = Vec::new();
+        let mut added = Vec::new();
+        while k < ops.len() && ops[k].kind != DiffLineKind::Context {
+            if ops[k].kind == DiffLineKind::Removed {
+                removed.push(ops[k].clone());
+            } else {
+                added.push(ops[k].clone());
+            }
+            k += 1;
+        }
+        out.extend(removed);
+        out.extend(added);
+    }
+    out
+}
+
+/// Turn grouped line ops into rendered diff lines, pairing `removed[i]` with
+/// `added[i]` within each change run for word-level highlighting. Input ops
+/// must already be grouped (all removed before all added within each change
+/// run) — see `group_runs`.
+pub fn segmentize(ops: Vec<LineOp>) -> Vec<DiffLine> {
+    let mut result = Vec::new();
+    let mut k = 0;
+    let n = ops.len();
+    while k < n {
+        if ops[k].kind == DiffLineKind::Context {
+            result.push(DiffLine {
+                kind: DiffLineKind::Context,
+                segments: vec![DiffSegment {
+                    text: ops[k].text.clone(),
+                    changed: false,
+                }],
+            });
+            k += 1;
+            continue;
+        }
+
+        let mut removed = Vec::new();
+        while k < n && ops[k].kind == DiffLineKind::Removed {
+            removed.push(ops[k].text.clone());
+            k += 1;
+        }
+        let mut added = Vec::new();
+        while k < n && ops[k].kind == DiffLineKind::Added {
+            added.push(ops[k].text.clone());
+            k += 1;
+        }
+
+        let pairs = removed.len().min(added.len());
+        let wds: Vec<_> = (0..pairs)
+            .map(|i| word_diff(&removed[i], &added[i]))
+            .collect();
+
+        for (i, text) in removed.iter().enumerate() {
+            let segs = if i < pairs {
+                wds[i].as_ref().map(|(old, _)| old.clone())
+            } else {
+                None
+            }
+            .unwrap_or_else(|| {
+                vec![DiffSegment {
+                    text: text.clone(),
+                    changed: false,
+                }]
+            });
+            result.push(DiffLine {
+                kind: DiffLineKind::Removed,
+                segments: segs,
+            });
+        }
+        for (i, text) in added.iter().enumerate() {
+            let segs = if i < pairs {
+                wds[i].as_ref().map(|(_, new)| new.clone())
+            } else {
+                None
+            }
+            .unwrap_or_else(|| {
+                vec![DiffSegment {
+                    text: text.clone(),
+                    changed: false,
+                }]
+            });
+            result.push(DiffLine {
+                kind: DiffLineKind::Added,
+                segments: segs,
+            });
+        }
+    }
+    result
+}
+
+pub fn compute_edit_diff(old_lines: &[String], new_lines: &[String]) -> Vec<DiffLine> {
+    segmentize(group_runs(line_diff_ops(old_lines, new_lines)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(s: &str) -> Vec<String> {
+        s.lines().map(str::to_string).collect()
+    }
+
+    #[test]
+    fn tokenize_splits_words_whitespace_and_punctuation() {
+        assert_eq!(
+            tokenize("foo_bar(1, 2)"),
+            vec!["foo_bar", "(", "1", ",", " ", "2", ")"]
+        );
+    }
+
+    #[test]
+    fn word_diff_highlights_the_changed_token_when_lines_are_similar() {
+        let (old, new) = word_diff(r#"    println!("old");"#, r#"    println!("new");"#).unwrap();
+        assert!(old.iter().any(|s| s.changed && s.text == "old"));
+        assert!(new.iter().any(|s| s.changed && s.text == "new"));
+    }
+
+    #[test]
+    fn word_diff_returns_none_for_dissimilar_lines() {
+        assert!(word_diff("completely different", "totally unrelated text").is_none());
+    }
+
+    #[test]
+    fn compute_edit_diff_preserves_unchanged_context_lines() {
+        let old = lines("fn main() {\n    println!(\"old\");\n}");
+        let new = lines("fn main() {\n    println!(\"new\");\n}");
+        let diff = compute_edit_diff(&old, &new);
+        let kinds: Vec<_> = diff.iter().map(|l| l.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DiffLineKind::Context,
+                DiffLineKind::Removed,
+                DiffLineKind::Added,
+                DiffLineKind::Context,
+            ]
+        );
+    }
+}

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -1,8 +1,10 @@
 pub mod cache;
 pub mod compression;
+pub mod diff;
 pub mod discover;
 pub mod entry;
 pub mod ongoing;
+pub mod patch;
 pub mod session;
 pub mod spawn;
 pub mod toolcall;

--- a/src-tauri/src/parser/patch.rs
+++ b/src-tauri/src/parser/patch.rs
@@ -1,0 +1,318 @@
+//! Parse a Codex `apply_patch` body into per-file, per-hunk structured diffs.
+//! Ported from `shared/patch.ts` — keep the two in sync.
+//!
+//! The patch text Codex logs in a `custom_tool_call` `input` looks like:
+//!
+//! ```text
+//! *** Begin Patch
+//! *** Update File: path/to/file
+//! @@ optional context heading
+//!  unchanged line   (leading space)
+//! -removed line
+//! +added line
+//! *** End Patch
+//! ```
+//!
+//! We honour the patch's own +/-/context classification (rather than
+//! re-diffing) and reuse `group_runs` + `segmentize` from `diff.rs` to add
+//! word-level highlighting on each paired removed/added run.
+
+use super::diff::{group_runs, segmentize, DiffLine, DiffLineKind, LineOp};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatchFileOp {
+    Add,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PatchHunk {
+    /// Text after the `@@` marker, if any (empty for the implicit first hunk).
+    pub header: String,
+    pub lines: Vec<DiffLine>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PatchFile {
+    pub path: String,
+    pub op: PatchFileOp,
+    /// Destination path when the patch renames/moves the file (`*** Move to:`).
+    pub move_path: Option<String>,
+    pub hunks: Vec<PatchHunk>,
+}
+
+const BEGIN: &str = "*** Begin Patch";
+const END: &str = "*** End Patch";
+const ADD: &str = "*** Add File: ";
+const UPDATE: &str = "*** Update File: ";
+const DELETE: &str = "*** Delete File: ";
+const MOVE: &str = "*** Move to: ";
+
+fn looks_like_patch(patch: &str) -> bool {
+    patch.contains(BEGIN) || patch.contains(ADD) || patch.contains(UPDATE) || patch.contains(DELETE)
+}
+
+/// Parse a Codex apply_patch body. Returns `None` when the text isn't a
+/// recognised patch (callers then fall back to rendering it as raw text).
+pub fn parse_apply_patch(patch: &str) -> Option<Vec<PatchFile>> {
+    if !looks_like_patch(patch) {
+        return None;
+    }
+
+    let mut lines: Vec<&str> = patch.split('\n').collect();
+    // Drop a single trailing empty element from a terminal newline so it
+    // doesn't surface as a spurious blank context line on the last file.
+    if lines.last() == Some(&"") {
+        lines.pop();
+    }
+
+    let mut files: Vec<PatchFile> = Vec::new();
+    let mut hunk_ops: Vec<LineOp> = Vec::new();
+    let mut hunk_header = String::new();
+
+    fn end_hunk(files: &mut [PatchFile], hunk_ops: &mut Vec<LineOp>, hunk_header: &mut String) {
+        if !hunk_ops.is_empty() {
+            if let Some(f) = files.last_mut() {
+                f.hunks.push(PatchHunk {
+                    header: hunk_header.clone(),
+                    lines: segmentize(group_runs(std::mem::take(hunk_ops))),
+                });
+            }
+        }
+        hunk_ops.clear();
+        hunk_header.clear();
+    }
+
+    for raw in lines {
+        if raw.starts_with(BEGIN) || raw.starts_with(END) {
+            continue;
+        }
+
+        if raw.starts_with(ADD) || raw.starts_with(UPDATE) || raw.starts_with(DELETE) {
+            end_hunk(&mut files, &mut hunk_ops, &mut hunk_header);
+            let (op, prefix) = if raw.starts_with(ADD) {
+                (PatchFileOp::Add, ADD)
+            } else if raw.starts_with(UPDATE) {
+                (PatchFileOp::Update, UPDATE)
+            } else {
+                (PatchFileOp::Delete, DELETE)
+            };
+            files.push(PatchFile {
+                path: raw[prefix.len()..].trim().to_string(),
+                op,
+                move_path: None,
+                hunks: Vec::new(),
+            });
+            continue;
+        }
+
+        if let Some(dest) = raw.strip_prefix(MOVE) {
+            if let Some(f) = files.last_mut() {
+                f.move_path = Some(dest.trim().to_string());
+            }
+            continue;
+        }
+
+        if let Some(header) = raw.strip_prefix("@@") {
+            end_hunk(&mut files, &mut hunk_ops, &mut hunk_header);
+            hunk_header = header.trim().to_string();
+            continue;
+        }
+
+        if files.is_empty() {
+            continue; // stray line outside any file section
+        }
+
+        if let Some(text) = raw.strip_prefix('+') {
+            hunk_ops.push(LineOp {
+                kind: DiffLineKind::Added,
+                text: text.to_string(),
+            });
+        } else if let Some(text) = raw.strip_prefix('-') {
+            hunk_ops.push(LineOp {
+                kind: DiffLineKind::Removed,
+                text: text.to_string(),
+            });
+        } else if let Some(text) = raw.strip_prefix(' ') {
+            hunk_ops.push(LineOp {
+                kind: DiffLineKind::Context,
+                text: text.to_string(),
+            });
+        } else {
+            hunk_ops.push(LineOp {
+                kind: DiffLineKind::Context,
+                text: raw.to_string(),
+            }); // blank/untagged context line
+        }
+    }
+    end_hunk(&mut files, &mut hunk_ops, &mut hunk_header);
+
+    if files.is_empty() {
+        None
+    } else {
+        Some(files)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_none_for_non_patch_text() {
+        assert!(parse_apply_patch("just some output text").is_none());
+        assert!(parse_apply_patch("").is_none());
+    }
+
+    #[test]
+    fn parses_an_update_with_context_removed_and_added_lines() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Update File: src/main.rs",
+            "@@",
+            " fn main() {",
+            "-    println!(\"old\");",
+            "+    println!(\"new\");",
+            " }",
+            "*** End Patch",
+        ]
+        .join("\n");
+
+        let files = parse_apply_patch(&patch).unwrap();
+        assert_eq!(files.len(), 1);
+        let file = &files[0];
+        assert_eq!(file.op, PatchFileOp::Update);
+        assert_eq!(file.path, "src/main.rs");
+        assert_eq!(file.move_path, None);
+        assert_eq!(file.hunks.len(), 1);
+
+        let lines = &file.hunks[0].lines;
+        let kinds: Vec<_> = lines.iter().map(|l| l.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DiffLineKind::Context,
+                DiffLineKind::Removed,
+                DiffLineKind::Added,
+                DiffLineKind::Context,
+            ]
+        );
+        let line0: String = lines[0].segments.iter().map(|s| s.text.clone()).collect();
+        assert_eq!(line0, "fn main() {");
+        assert!(lines[1].segments.iter().any(|s| s.changed));
+        assert!(lines[2].segments.iter().any(|s| s.changed));
+        let removed: String = lines[1].segments.iter().map(|s| s.text.clone()).collect();
+        assert_eq!(removed, "    println!(\"old\");");
+        let added: String = lines[2].segments.iter().map(|s| s.text.clone()).collect();
+        assert_eq!(added, "    println!(\"new\");");
+    }
+
+    #[test]
+    fn parses_an_added_file_with_all_added_lines() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Add File: docs/README.md",
+            "+# Title",
+            "+",
+            "+body",
+            "*** End Patch",
+        ]
+        .join("\n");
+
+        let files = parse_apply_patch(&patch).unwrap();
+        assert_eq!(files[0].op, PatchFileOp::Add);
+        assert_eq!(files[0].path, "docs/README.md");
+        let lines = &files[0].hunks[0].lines;
+        let kinds: Vec<_> = lines.iter().map(|l| l.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DiffLineKind::Added,
+                DiffLineKind::Added,
+                DiffLineKind::Added
+            ]
+        );
+        let texts: Vec<String> = lines
+            .iter()
+            .map(|l| l.segments.iter().map(|s| s.text.clone()).collect())
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["# Title".to_string(), String::new(), "body".to_string()]
+        );
+    }
+
+    #[test]
+    fn parses_a_deleted_file_header_with_no_body() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Delete File: old/file.txt",
+            "*** End Patch",
+        ]
+        .join("\n");
+        let files = parse_apply_patch(&patch).unwrap();
+        assert_eq!(files[0].op, PatchFileOp::Delete);
+        assert_eq!(files[0].path, "old/file.txt");
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn captures_a_move_rename_target() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Update File: a/old.ts",
+            "*** Move to: a/new.ts",
+            "@@",
+            "-const x = 1;",
+            "+const x = 2;",
+            "*** End Patch",
+        ]
+        .join("\n");
+        let files = parse_apply_patch(&patch).unwrap();
+        assert_eq!(files[0].move_path, Some("a/new.ts".to_string()));
+    }
+
+    #[test]
+    fn splits_multiple_files_and_multiple_hunks() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Update File: a.ts",
+            "@@ first hunk",
+            "-a",
+            "+b",
+            "@@ second hunk",
+            " keep",
+            "+added",
+            "*** Update File: b.ts",
+            "@@",
+            "-gone",
+            "*** End Patch",
+        ]
+        .join("\n");
+        let files = parse_apply_patch(&patch).unwrap();
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].path, "a.ts");
+        assert_eq!(files[0].hunks.len(), 2);
+        assert_eq!(files[0].hunks[0].header, "first hunk");
+        assert_eq!(files[0].hunks[1].header, "second hunk");
+        assert_eq!(files[1].path, "b.ts");
+        let kinds: Vec<_> = files[1].hunks[0].lines.iter().map(|l| l.kind).collect();
+        assert_eq!(kinds, vec![DiffLineKind::Removed]);
+    }
+
+    #[test]
+    fn does_not_emit_a_spurious_blank_line_from_a_trailing_newline() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Add File: f.txt",
+            "+hi",
+            "*** End Patch",
+            "",
+        ]
+        .join("\n");
+        let files = parse_apply_patch(&patch).unwrap();
+        let kinds: Vec<_> = files[0].hunks[0].lines.iter().map(|l| l.kind).collect();
+        assert_eq!(kinds, vec![DiffLineKind::Added]);
+    }
+}

--- a/src-tauri/src/tui/app.rs
+++ b/src-tauri/src/tui/app.rs
@@ -18,6 +18,7 @@ pub enum Screen {
 pub enum DetailFocus {
     List,
     Item,
+    Team,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,7 +30,17 @@ pub enum ItemPanel {
 #[derive(Debug, Clone)]
 pub enum PickerRow {
     DateHeader(String),
+    ProjectHeader(String),
     Session(usize),
+}
+
+/// How the Session Picker groups sessions — toggled with `p` (mirrors the
+/// project sidebar in the web/TUI reference, adapted to Codex's flat
+/// date-based session layout by grouping on each session's recorded `cwd`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupMode {
+    Date,
+    Project,
 }
 
 /// One selectable line in a session's detail list. Turn headers, the user
@@ -52,6 +63,7 @@ pub struct OpenSession {
     pub focus: DetailFocus,
     pub item_panel: ItemPanel,
     pub item_scroll: u16,
+    pub team_state: ListState,
     last_mtime: Option<std::time::SystemTime>,
 }
 
@@ -72,6 +84,7 @@ impl OpenSession {
             focus: DetailFocus::List,
             item_panel: ItemPanel::Primary,
             item_scroll: 0,
+            team_state: ListState::default(),
             last_mtime,
         }
     }
@@ -150,6 +163,50 @@ impl OpenSession {
         }
         tool.worker_session.as_ref().map(|b| b.as_ref().clone())
     }
+
+    /// `(turn_idx, tool_idx)` of every `spawn_agent` call across the session —
+    /// the roster shown by the Team board (`t` key), mirroring the collab
+    /// tracking the desktop/web UI shows per-turn but flattened into a single
+    /// cross-turn view.
+    pub fn team_rows(&self) -> Vec<(usize, usize)> {
+        self.session
+            .turns
+            .iter()
+            .enumerate()
+            .flat_map(|(t, turn)| {
+                turn.tool_calls
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, tc)| tc.kind == ToolKind::SpawnAgent)
+                    .map(move |(tc, _)| (t, tc))
+            })
+            .collect()
+    }
+
+    fn enter_team_view(&mut self) {
+        self.focus = DetailFocus::Team;
+        if self.team_state.selected().is_none() && !self.team_rows().is_empty() {
+            self.team_state.select(Some(0));
+        }
+    }
+
+    fn move_team_selection(&mut self, delta: i32) {
+        let len = self.team_rows().len() as i32;
+        if len == 0 {
+            return;
+        }
+        let current = self.team_state.selected().unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, len - 1);
+        self.team_state.select(Some(next as usize));
+    }
+
+    /// The worker session embedded on the currently selected Team board row,
+    /// if one was resolved during parsing (see `selected_worker_session`).
+    fn selected_team_worker_session(&self) -> Option<CodexSession> {
+        let (t, tc) = *self.team_rows().get(self.team_state.selected()?)?;
+        let tool = self.session.turns.get(t)?.tool_calls.get(tc)?;
+        tool.worker_session.as_ref().map(|b| b.as_ref().clone())
+    }
 }
 
 /// Flatten a session's turns into a linear list of rows, interleaving agent
@@ -200,6 +257,7 @@ pub struct App {
     pub picker_state: ListState,
     pub search_mode: bool,
     pub search_query: String,
+    pub group_mode: GroupMode,
     pub screen: Screen,
     pub stack: Vec<OpenSession>,
     pub show_help: bool,
@@ -217,6 +275,7 @@ impl App {
             picker_state: ListState::default(),
             search_mode: false,
             search_query: String::new(),
+            group_mode: GroupMode::Date,
             screen: Screen::Picker,
             stack: Vec::new(),
             show_help: false,
@@ -243,13 +302,29 @@ impl App {
 
     fn rebuild_picker_rows(&mut self) {
         let query = self.search_query.to_lowercase();
+        self.filtered_rows = match self.group_mode {
+            GroupMode::Date => self.build_rows_by_date(&query),
+            GroupMode::Project => self.build_rows_by_project(&query),
+        };
+        let len = self.filtered_rows.len();
+        match self.picker_state.selected() {
+            Some(sel) if sel >= len => self.picker_state.select(len.checked_sub(1)),
+            None if len > 0 => self.picker_state.select(Some(0)),
+            _ => {}
+        }
+    }
+
+    /// Sessions are already newest-first and contiguous per `date_group`
+    /// (the filename's ISO timestamp sorts that way), so a single pass groups
+    /// them without re-sorting.
+    fn build_rows_by_date(&self, query: &str) -> Vec<PickerRow> {
         let mut rows = Vec::new();
         let mut i = 0;
         while i < self.sessions.len() {
             let group = self.sessions[i].date_group.clone();
             let mut group_indices = Vec::new();
             while i < self.sessions.len() && self.sessions[i].date_group == group {
-                if query.is_empty() || session_matches(&self.sessions[i], &query) {
+                if query.is_empty() || session_matches(&self.sessions[i], query) {
                     group_indices.push(i);
                 }
                 i += 1;
@@ -262,13 +337,35 @@ impl App {
                 rows.extend(group_indices.into_iter().map(PickerRow::Session));
             }
         }
-        self.filtered_rows = rows;
-        let len = self.filtered_rows.len();
-        match self.picker_state.selected() {
-            Some(sel) if sel >= len => self.picker_state.select(len.checked_sub(1)),
-            None if len > 0 => self.picker_state.select(Some(0)),
-            _ => {}
+        rows
+    }
+
+    /// Groups by each session's recorded `cwd` rather than by date. Unlike
+    /// date groups, a project's sessions aren't contiguous in `self.sessions`
+    /// (newest-first overall, not per-project), so this collects into a
+    /// sorted map first; insertion order per key still preserves the
+    /// newest-first ordering within each project.
+    fn build_rows_by_project(&self, query: &str) -> Vec<PickerRow> {
+        let mut by_project: std::collections::BTreeMap<String, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        for (i, s) in self.sessions.iter().enumerate() {
+            if !query.is_empty() && !session_matches(s, query) {
+                continue;
+            }
+            let key = s
+                .cwd
+                .clone()
+                .unwrap_or_else(|| "(unknown project)".to_string());
+            by_project.entry(key).or_default().push(i);
         }
+        let mut rows = Vec::new();
+        for (project, indices) in by_project {
+            rows.push(PickerRow::ProjectHeader(project.clone()));
+            if !self.collapsed_groups.contains(&project) {
+                rows.extend(indices.into_iter().map(PickerRow::Session));
+            }
+        }
+        rows
     }
 
     pub fn on_tick(&mut self) {
@@ -336,6 +433,7 @@ impl App {
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Char('/') => self.search_mode = true,
             KeyCode::Char('r') => self.reload_sessions(),
+            KeyCode::Char('p') => self.toggle_group_mode(),
             KeyCode::Down | KeyCode::Char('j') => self.move_picker(1),
             KeyCode::Up | KeyCode::Char('k') => self.move_picker(-1),
             KeyCode::PageDown => self.move_picker(10),
@@ -373,7 +471,7 @@ impl App {
             return;
         };
         match row {
-            PickerRow::DateHeader(group) => {
+            PickerRow::DateHeader(group) | PickerRow::ProjectHeader(group) => {
                 if !self.collapsed_groups.remove(&group) {
                     self.collapsed_groups.insert(group);
                 }
@@ -381,6 +479,15 @@ impl App {
             }
             PickerRow::Session(idx) => self.open_session_by_index(idx),
         }
+    }
+
+    fn toggle_group_mode(&mut self) {
+        self.group_mode = match self.group_mode {
+            GroupMode::Date => GroupMode::Project,
+            GroupMode::Project => GroupMode::Date,
+        };
+        self.collapsed_groups.clear();
+        self.rebuild_picker_rows();
     }
 
     fn open_session_by_index(&mut self, idx: usize) {
@@ -409,6 +516,7 @@ impl App {
         match self.stack.last().unwrap().focus {
             DetailFocus::List => self.on_key_detail_list(code),
             DetailFocus::Item => self.on_key_detail_item(code),
+            DetailFocus::Team => self.on_key_detail_team(code),
         }
     }
 
@@ -435,6 +543,7 @@ impl App {
             KeyCode::Tab => self.stack.last_mut().unwrap().toggle_expand_selected(),
             KeyCode::Char('e') => self.stack.last_mut().unwrap().set_all_expanded(true),
             KeyCode::Char('c') => self.stack.last_mut().unwrap().set_all_expanded(false),
+            KeyCode::Char('t') => self.stack.last_mut().unwrap().enter_team_view(),
             KeyCode::Enter => {
                 let worker = self.stack.last().unwrap().selected_worker_session();
                 if let Some(session) = worker {
@@ -442,6 +551,28 @@ impl App {
                     self.stack.push(OpenSession::new(session, path));
                 } else {
                     self.stack.last_mut().unwrap().enter_item_view();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_key_detail_team(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc | KeyCode::Char('t') => {
+                self.stack.last_mut().unwrap().focus = DetailFocus::List;
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.stack.last_mut().unwrap().move_team_selection(1)
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.stack.last_mut().unwrap().move_team_selection(-1)
+            }
+            KeyCode::Enter => {
+                let worker = self.stack.last().unwrap().selected_team_worker_session();
+                if let Some(session) = worker {
+                    let path = PathBuf::from(&session.path);
+                    self.stack.push(OpenSession::new(session, path));
                 }
             }
             _ => {}
@@ -509,6 +640,7 @@ mod tests {
             picker_state: ListState::default(),
             search_mode: false,
             search_query: String::new(),
+            group_mode: GroupMode::Date,
             screen: Screen::Picker,
             stack: Vec::new(),
             show_help: false,
@@ -539,6 +671,70 @@ mod tests {
         assert!(matches!(&app.filtered_rows[0], PickerRow::DateHeader(g) if g == "2026/05/08"));
         assert!(matches!(app.filtered_rows[1], PickerRow::Session(0)));
         assert!(matches!(&app.filtered_rows[2], PickerRow::DateHeader(g) if g == "2026/05/07"));
+    }
+
+    #[test]
+    fn toggle_group_mode_switches_from_date_to_project_grouping() {
+        let mut sessions = vec![
+            sample_session_info("s1", "2026/05/08", "2026-05-08T00:00:00Z"),
+            sample_session_info("s2", "2026/05/07", "2026-05-07T00:00:00Z"),
+        ];
+        sessions[0].cwd = Some("/repo/a".to_string());
+        sessions[1].cwd = Some("/repo/b".to_string());
+        let mut app = test_app(sessions);
+        assert_eq!(app.group_mode, GroupMode::Date);
+
+        app.toggle_group_mode();
+        assert_eq!(app.group_mode, GroupMode::Project);
+        // Sorted alphabetically by cwd (BTreeMap), unlike date grouping which
+        // preserves newest-first order.
+        assert_eq!(app.filtered_rows.len(), 4); // 2 project headers + 2 sessions
+        assert!(matches!(&app.filtered_rows[0], PickerRow::ProjectHeader(g) if g == "/repo/a"));
+        assert!(matches!(app.filtered_rows[1], PickerRow::Session(0)));
+        assert!(matches!(&app.filtered_rows[2], PickerRow::ProjectHeader(g) if g == "/repo/b"));
+        assert!(matches!(app.filtered_rows[3], PickerRow::Session(1)));
+
+        app.toggle_group_mode();
+        assert_eq!(app.group_mode, GroupMode::Date);
+    }
+
+    #[test]
+    fn build_rows_by_project_groups_sessions_sharing_a_cwd_and_buckets_unknown_ones() {
+        let mut sessions = vec![
+            sample_session_info("s1", "2026/05/08", "2026-05-08T00:00:00Z"),
+            sample_session_info("s2", "2026/05/07", "2026-05-07T00:00:00Z"),
+            sample_session_info("s3", "2026/05/06", "2026-05-06T00:00:00Z"),
+        ];
+        sessions[0].cwd = Some("/repo/a".to_string());
+        sessions[1].cwd = Some("/repo/a".to_string());
+        // s3 has no cwd — falls into the "(unknown project)" bucket.
+        let mut app = test_app(sessions);
+        app.toggle_group_mode();
+        assert_eq!(app.filtered_rows.len(), 5); // 2 project headers + 3 sessions
+        assert!(
+            matches!(&app.filtered_rows[0], PickerRow::ProjectHeader(g) if g == "(unknown project)")
+        );
+        assert!(matches!(app.filtered_rows[1], PickerRow::Session(2)));
+        assert!(matches!(&app.filtered_rows[2], PickerRow::ProjectHeader(g) if g == "/repo/a"));
+        assert!(matches!(app.filtered_rows[3], PickerRow::Session(0)));
+        assert!(matches!(app.filtered_rows[4], PickerRow::Session(1)));
+    }
+
+    #[test]
+    fn activate_picker_row_collapses_and_expands_a_project_group() {
+        let mut sessions = vec![sample_session_info(
+            "s1",
+            "2026/05/08",
+            "2026-05-08T00:00:00Z",
+        )];
+        sessions[0].cwd = Some("/repo/a".to_string());
+        let mut app = test_app(sessions);
+        app.toggle_group_mode();
+        app.picker_state.select(Some(0));
+        app.activate_picker_row();
+        assert_eq!(app.filtered_rows.len(), 1); // header only, session hidden
+        app.activate_picker_row();
+        assert_eq!(app.filtered_rows.len(), 2); // expanded again
     }
 
     #[test]
@@ -743,5 +939,111 @@ mod tests {
             .selected_worker_session()
             .expect("worker session embedded");
         assert_eq!(worker.id, "worker-session");
+    }
+
+    fn write_session_with_spawn_agent_pair(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("rollout-2026-04-27T16-50-45-parent.jsonl");
+        let worker_path = dir.join("rollout-2026-04-27T16-50-46-worker-session.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-27T04:50:45Z","type":"session_meta","payload":{"id":"parent","timestamp":"2026-04-27T04:50:45Z"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:02Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","arguments":"{\"agent_type\":\"worker\",\"message\":\"Collect evidence\"}","call_id":"call_spawn"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_spawn","output":"{\"agent_id\":\"worker-session\",\"nickname\":\"Parfit\"}"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1777279924.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            &worker_path,
+            r#"{"timestamp":"2026-04-27T04:50:46Z","type":"session_meta","payload":{"id":"worker-session","timestamp":"2026-04-27T04:50:46Z","cwd":"/tmp/worker"}}"#,
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn team_rows_is_empty_when_the_session_never_spawned_an_agent() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_tool_call(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let open = OpenSession::new(session, path);
+        assert!(open.team_rows().is_empty());
+    }
+
+    #[test]
+    fn team_rows_lists_every_spawn_agent_call_across_turns() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_spawn_agent_pair(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let open = OpenSession::new(session, path);
+        assert_eq!(open.team_rows(), vec![(0, 0)]);
+    }
+
+    #[test]
+    fn enter_team_view_focuses_team_and_selects_the_first_row() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_spawn_agent_pair(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.enter_team_view();
+        assert_eq!(open.focus, DetailFocus::Team);
+        assert_eq!(open.team_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn move_team_selection_clamps_at_bounds_with_a_single_row() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_spawn_agent_pair(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.enter_team_view();
+        open.move_team_selection(5);
+        assert_eq!(open.team_state.selected(), Some(0));
+        open.move_team_selection(-5);
+        assert_eq!(open.team_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn selected_team_worker_session_returns_the_embedded_worker() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_spawn_agent_pair(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.enter_team_view();
+        let worker = open
+            .selected_team_worker_session()
+            .expect("worker session embedded");
+        assert_eq!(worker.id, "worker-session");
+    }
+
+    #[test]
+    fn on_key_detail_team_t_returns_to_the_list_and_enter_opens_the_worker() {
+        let tmp = tempdir().unwrap();
+        write_session_with_spawn_agent_pair(tmp.path());
+        let mut app = App::new(tmp.path().to_path_buf());
+        // Sessions sort newest-first by filename timestamp, so the worker
+        // session (16:50:46) lands before its parent (16:50:45) — pick the
+        // row whose id is "parent" rather than assuming an index.
+        let parent_idx = app
+            .sessions
+            .iter()
+            .position(|s| s.id == "parent")
+            .expect("parent session discovered");
+        let row_idx = app
+            .filtered_rows
+            .iter()
+            .position(|row| matches!(row, PickerRow::Session(i) if *i == parent_idx))
+            .expect("parent session has a picker row");
+        app.picker_state.select(Some(row_idx));
+        app.activate_picker_row();
+        app.on_key(KeyCode::Char('t'), KeyModifiers::NONE);
+        assert_eq!(app.stack.last().unwrap().focus, DetailFocus::Team);
+
+        app.on_key(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.stack.len(), 2);
+        assert_eq!(app.stack.last().unwrap().session.id, "worker-session");
     }
 }

--- a/src-tauri/src/tui/app.rs
+++ b/src-tauri/src/tui/app.rs
@@ -1,0 +1,747 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::widgets::ListState;
+
+use crate::parser::discover::{discover_sessions, CodexSessionInfo};
+use crate::parser::session::{parse_session, CodexSession};
+use crate::parser::toolcall::ToolKind;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Screen {
+    Picker,
+    Detail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailFocus {
+    List,
+    Item,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemPanel {
+    Primary,
+    Secondary,
+}
+
+#[derive(Debug, Clone)]
+pub enum PickerRow {
+    DateHeader(String),
+    Session(usize),
+}
+
+/// One selectable line in a session's detail list. Turn headers, the user
+/// message, agent messages, and tool calls are interleaved in stream order
+/// (see `build_rows`), mirroring how the desktop UI lays out a turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Row {
+    TurnHeader(usize),
+    UserMessage(usize),
+    Agent(usize, usize),
+    Tool(usize, usize),
+}
+
+pub struct OpenSession {
+    pub session: CodexSession,
+    pub path: PathBuf,
+    pub rows: Vec<Row>,
+    pub list_state: ListState,
+    pub expanded: HashSet<(usize, usize)>,
+    pub focus: DetailFocus,
+    pub item_panel: ItemPanel,
+    pub item_scroll: u16,
+    last_mtime: Option<std::time::SystemTime>,
+}
+
+impl OpenSession {
+    fn new(session: CodexSession, path: PathBuf) -> Self {
+        let rows = build_rows(&session);
+        let mut list_state = ListState::default();
+        if !rows.is_empty() {
+            list_state.select(Some(0));
+        }
+        let last_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+        OpenSession {
+            session,
+            path,
+            rows,
+            list_state,
+            expanded: HashSet::new(),
+            focus: DetailFocus::List,
+            item_panel: ItemPanel::Primary,
+            item_scroll: 0,
+            last_mtime,
+        }
+    }
+
+    fn refresh(&mut self) {
+        if let Ok(session) = parse_session(&self.path) {
+            self.rows = build_rows(&session);
+            self.session = session;
+            let len = self.rows.len();
+            match self.list_state.selected() {
+                Some(sel) if sel >= len => {
+                    self.list_state.select(len.checked_sub(1));
+                }
+                None if len > 0 => self.list_state.select(Some(0)),
+                _ => {}
+            }
+        }
+    }
+
+    fn move_selection(&mut self, delta: i32) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let len = self.rows.len() as i32;
+        let current = self.list_state.selected().unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, len - 1);
+        self.list_state.select(Some(next as usize));
+    }
+
+    fn toggle_expand_selected(&mut self) {
+        if let Some(Row::Tool(t, tc)) = self.selected_row() {
+            let key = (t, tc);
+            if !self.expanded.remove(&key) {
+                self.expanded.insert(key);
+            }
+        }
+    }
+
+    fn set_all_expanded(&mut self, expand: bool) {
+        if expand {
+            for row in &self.rows {
+                if let Row::Tool(t, tc) = row {
+                    self.expanded.insert((*t, *tc));
+                }
+            }
+        } else {
+            self.expanded.clear();
+        }
+    }
+
+    fn enter_item_view(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.focus = DetailFocus::Item;
+        self.item_panel = ItemPanel::Primary;
+        self.item_scroll = 0;
+    }
+
+    pub fn selected_row(&self) -> Option<Row> {
+        self.list_state
+            .selected()
+            .and_then(|i| self.rows.get(i))
+            .copied()
+    }
+
+    /// If the selected row is a `spawn_agent` call whose worker session was embedded
+    /// during parsing, returns a clone the caller can push onto the navigation stack.
+    fn selected_worker_session(&self) -> Option<CodexSession> {
+        let Row::Tool(t, tc) = self.selected_row()? else {
+            return None;
+        };
+        let tool = self.session.turns.get(t)?.tool_calls.get(tc)?;
+        if tool.kind != ToolKind::SpawnAgent {
+            return None;
+        }
+        tool.worker_session.as_ref().map(|b| b.as_ref().clone())
+    }
+}
+
+/// Flatten a session's turns into a linear list of rows, interleaving agent
+/// messages and tool calls by their original stream order so the list reads
+/// the way the conversation actually happened.
+fn build_rows(session: &CodexSession) -> Vec<Row> {
+    let mut rows = Vec::new();
+    for (t_idx, turn) in session.turns.iter().enumerate() {
+        rows.push(Row::TurnHeader(t_idx));
+        if turn.user_message.is_some() {
+            rows.push(Row::UserMessage(t_idx));
+        }
+        let mut combined: Vec<(usize, Row)> = Vec::new();
+        for (m_idx, msg) in turn.agent_messages.iter().enumerate() {
+            combined.push((msg.order, Row::Agent(t_idx, m_idx)));
+        }
+        for (tc_idx, order) in turn.tool_call_orders.iter().enumerate() {
+            combined.push((*order, Row::Tool(t_idx, tc_idx)));
+        }
+        combined.sort_by_key(|(order, _)| *order);
+        rows.extend(combined.into_iter().map(|(_, row)| row));
+    }
+    rows
+}
+
+fn session_matches(s: &CodexSessionInfo, query: &str) -> bool {
+    let fields = [
+        Some(s.id.as_str()),
+        s.cwd.as_deref(),
+        s.git_branch.as_deref(),
+        s.model.as_deref(),
+        s.thread_name.as_deref(),
+        s.ai_title.as_deref(),
+        s.worker_nickname.as_deref(),
+        s.worker_role.as_deref(),
+    ];
+    fields
+        .into_iter()
+        .flatten()
+        .any(|f| f.to_lowercase().contains(query))
+}
+
+pub struct App {
+    pub sessions_dir: PathBuf,
+    pub sessions: Vec<CodexSessionInfo>,
+    pub filtered_rows: Vec<PickerRow>,
+    pub collapsed_groups: HashSet<String>,
+    pub picker_state: ListState,
+    pub search_mode: bool,
+    pub search_query: String,
+    pub screen: Screen,
+    pub stack: Vec<OpenSession>,
+    pub show_help: bool,
+    pub status_message: Option<String>,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new(sessions_dir: PathBuf) -> Self {
+        let mut app = App {
+            sessions_dir,
+            sessions: Vec::new(),
+            filtered_rows: Vec::new(),
+            collapsed_groups: HashSet::new(),
+            picker_state: ListState::default(),
+            search_mode: false,
+            search_query: String::new(),
+            screen: Screen::Picker,
+            stack: Vec::new(),
+            show_help: false,
+            status_message: None,
+            should_quit: false,
+        };
+        app.reload_sessions();
+        app
+    }
+
+    pub fn reload_sessions(&mut self) {
+        match discover_sessions(&self.sessions_dir) {
+            Ok(sessions) => {
+                self.sessions = sessions;
+                self.status_message = None;
+            }
+            Err(e) => {
+                self.sessions = Vec::new();
+                self.status_message = Some(format!("failed to scan sessions dir: {e}"));
+            }
+        }
+        self.rebuild_picker_rows();
+    }
+
+    fn rebuild_picker_rows(&mut self) {
+        let query = self.search_query.to_lowercase();
+        let mut rows = Vec::new();
+        let mut i = 0;
+        while i < self.sessions.len() {
+            let group = self.sessions[i].date_group.clone();
+            let mut group_indices = Vec::new();
+            while i < self.sessions.len() && self.sessions[i].date_group == group {
+                if query.is_empty() || session_matches(&self.sessions[i], &query) {
+                    group_indices.push(i);
+                }
+                i += 1;
+            }
+            if group_indices.is_empty() {
+                continue;
+            }
+            rows.push(PickerRow::DateHeader(group.clone()));
+            if !self.collapsed_groups.contains(&group) {
+                rows.extend(group_indices.into_iter().map(PickerRow::Session));
+            }
+        }
+        self.filtered_rows = rows;
+        let len = self.filtered_rows.len();
+        match self.picker_state.selected() {
+            Some(sel) if sel >= len => self.picker_state.select(len.checked_sub(1)),
+            None if len > 0 => self.picker_state.select(Some(0)),
+            _ => {}
+        }
+    }
+
+    pub fn on_tick(&mut self) {
+        if self.screen != Screen::Detail {
+            return;
+        }
+        let Some(open) = self.stack.last_mut() else {
+            return;
+        };
+        let Ok(modified) = std::fs::metadata(&open.path).and_then(|m| m.modified()) else {
+            return;
+        };
+        if Some(modified) != open.last_mtime {
+            open.last_mtime = Some(modified);
+            open.refresh();
+        }
+    }
+
+    pub fn on_key(&mut self, code: KeyCode, modifiers: KeyModifiers) {
+        if modifiers.contains(KeyModifiers::CONTROL) && code == KeyCode::Char('c') {
+            self.should_quit = true;
+            return;
+        }
+        if self.show_help {
+            if matches!(
+                code,
+                KeyCode::Char('?') | KeyCode::Esc | KeyCode::Char('q') | KeyCode::Enter
+            ) {
+                self.show_help = false;
+            }
+            return;
+        }
+        if !self.search_mode && code == KeyCode::Char('?') {
+            self.show_help = true;
+            return;
+        }
+        match self.screen {
+            Screen::Picker => self.on_key_picker(code),
+            Screen::Detail => self.on_key_detail(code),
+        }
+    }
+
+    fn on_key_picker(&mut self, code: KeyCode) {
+        if self.search_mode {
+            match code {
+                KeyCode::Esc => {
+                    self.search_mode = false;
+                    self.search_query.clear();
+                    self.rebuild_picker_rows();
+                }
+                KeyCode::Enter => self.search_mode = false,
+                KeyCode::Backspace => {
+                    self.search_query.pop();
+                    self.rebuild_picker_rows();
+                }
+                KeyCode::Char(c) => {
+                    self.search_query.push(c);
+                    self.rebuild_picker_rows();
+                }
+                _ => {}
+            }
+            return;
+        }
+        match code {
+            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('/') => self.search_mode = true,
+            KeyCode::Char('r') => self.reload_sessions(),
+            KeyCode::Down | KeyCode::Char('j') => self.move_picker(1),
+            KeyCode::Up | KeyCode::Char('k') => self.move_picker(-1),
+            KeyCode::PageDown => self.move_picker(10),
+            KeyCode::PageUp => self.move_picker(-10),
+            KeyCode::Home => {
+                if !self.filtered_rows.is_empty() {
+                    self.picker_state.select(Some(0));
+                }
+            }
+            KeyCode::End => {
+                if !self.filtered_rows.is_empty() {
+                    self.picker_state.select(Some(self.filtered_rows.len() - 1));
+                }
+            }
+            KeyCode::Enter | KeyCode::Char(' ') => self.activate_picker_row(),
+            _ => {}
+        }
+    }
+
+    fn move_picker(&mut self, delta: i32) {
+        if self.filtered_rows.is_empty() {
+            return;
+        }
+        let len = self.filtered_rows.len() as i32;
+        let current = self.picker_state.selected().unwrap_or(0) as i32;
+        let next = (current + delta).clamp(0, len - 1);
+        self.picker_state.select(Some(next as usize));
+    }
+
+    fn activate_picker_row(&mut self) {
+        let Some(sel) = self.picker_state.selected() else {
+            return;
+        };
+        let Some(row) = self.filtered_rows.get(sel).cloned() else {
+            return;
+        };
+        match row {
+            PickerRow::DateHeader(group) => {
+                if !self.collapsed_groups.remove(&group) {
+                    self.collapsed_groups.insert(group);
+                }
+                self.rebuild_picker_rows();
+            }
+            PickerRow::Session(idx) => self.open_session_by_index(idx),
+        }
+    }
+
+    fn open_session_by_index(&mut self, idx: usize) {
+        let Some(info) = self.sessions.get(idx) else {
+            return;
+        };
+        let path = PathBuf::from(&info.path);
+        match parse_session(&path) {
+            Ok(session) => {
+                self.stack.clear();
+                self.stack.push(OpenSession::new(session, path));
+                self.screen = Screen::Detail;
+                self.status_message = None;
+            }
+            Err(e) => {
+                self.status_message = Some(format!("failed to parse session: {e}"));
+            }
+        }
+    }
+
+    fn on_key_detail(&mut self, code: KeyCode) {
+        if self.stack.is_empty() {
+            self.screen = Screen::Picker;
+            return;
+        }
+        match self.stack.last().unwrap().focus {
+            DetailFocus::List => self.on_key_detail_list(code),
+            DetailFocus::Item => self.on_key_detail_item(code),
+        }
+    }
+
+    fn on_key_detail_list(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.stack.pop();
+                if self.stack.is_empty() {
+                    self.screen = Screen::Picker;
+                }
+            }
+            KeyCode::Char('r') => self.stack.last_mut().unwrap().refresh(),
+            KeyCode::Down | KeyCode::Char('j') => self.stack.last_mut().unwrap().move_selection(1),
+            KeyCode::Up | KeyCode::Char('k') => self.stack.last_mut().unwrap().move_selection(-1),
+            KeyCode::PageDown => self.stack.last_mut().unwrap().move_selection(10),
+            KeyCode::PageUp => self.stack.last_mut().unwrap().move_selection(-10),
+            KeyCode::Home => self.stack.last_mut().unwrap().list_state.select(Some(0)),
+            KeyCode::End => {
+                let open = self.stack.last_mut().unwrap();
+                if !open.rows.is_empty() {
+                    open.list_state.select(Some(open.rows.len() - 1));
+                }
+            }
+            KeyCode::Tab => self.stack.last_mut().unwrap().toggle_expand_selected(),
+            KeyCode::Char('e') => self.stack.last_mut().unwrap().set_all_expanded(true),
+            KeyCode::Char('c') => self.stack.last_mut().unwrap().set_all_expanded(false),
+            KeyCode::Enter => {
+                let worker = self.stack.last().unwrap().selected_worker_session();
+                if let Some(session) = worker {
+                    let path = PathBuf::from(&session.path);
+                    self.stack.push(OpenSession::new(session, path));
+                } else {
+                    self.stack.last_mut().unwrap().enter_item_view();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_key_detail_item(&mut self, code: KeyCode) {
+        let open = self.stack.last_mut().unwrap();
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc | KeyCode::Enter => open.focus = DetailFocus::List,
+            KeyCode::Left | KeyCode::Char('h') => open.item_panel = ItemPanel::Primary,
+            KeyCode::Right | KeyCode::Char('l') => open.item_panel = ItemPanel::Secondary,
+            KeyCode::Down | KeyCode::Char('j') => {
+                open.item_scroll = open.item_scroll.saturating_add(1)
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                open.item_scroll = open.item_scroll.saturating_sub(1)
+            }
+            KeyCode::PageDown => open.item_scroll = open.item_scroll.saturating_add(10),
+            KeyCode::PageUp => open.item_scroll = open.item_scroll.saturating_sub(10),
+            KeyCode::Home => open.item_scroll = 0,
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_session_info(id: &str, date_group: &str, start_time: &str) -> CodexSessionInfo {
+        CodexSessionInfo {
+            id: id.to_string(),
+            path: format!("/tmp/{id}.jsonl"),
+            cwd: None,
+            git_branch: None,
+            originator: None,
+            model: None,
+            cli_version: None,
+            thread_name: None,
+            turn_count: 1,
+            start_time: start_time.to_string(),
+            end_time: None,
+            total_tokens: None,
+            is_ongoing: false,
+            is_external_worker: false,
+            is_inline_worker: false,
+            worker_nickname: None,
+            worker_role: None,
+            spawned_worker_ids: Vec::new(),
+            date_group: date_group.to_string(),
+            ai_title: None,
+            is_headless: false,
+            is_archived: false,
+        }
+    }
+
+    fn test_app(sessions: Vec<CodexSessionInfo>) -> App {
+        let mut app = App {
+            sessions_dir: PathBuf::from("/tmp"),
+            sessions,
+            filtered_rows: Vec::new(),
+            collapsed_groups: HashSet::new(),
+            picker_state: ListState::default(),
+            search_mode: false,
+            search_query: String::new(),
+            screen: Screen::Picker,
+            stack: Vec::new(),
+            show_help: false,
+            status_message: None,
+            should_quit: false,
+        };
+        app.rebuild_picker_rows();
+        app
+    }
+
+    #[test]
+    fn session_matches_checks_multiple_fields_case_insensitively() {
+        let mut s = sample_session_info("s1", "2026/05/07", "2026-05-07T00:00:00Z");
+        s.cwd = Some("/home/user/MyProject".to_string());
+        assert!(session_matches(&s, "myproject"));
+        assert!(!session_matches(&s, "other"));
+    }
+
+    #[test]
+    fn rebuild_picker_rows_groups_sessions_by_date() {
+        let sessions = vec![
+            sample_session_info("s1", "2026/05/08", "2026-05-08T00:00:00Z"),
+            sample_session_info("s2", "2026/05/07", "2026-05-07T00:00:00Z"),
+            sample_session_info("s3", "2026/05/07", "2026-05-07T01:00:00Z"),
+        ];
+        let app = test_app(sessions);
+        assert_eq!(app.filtered_rows.len(), 5); // 2 headers + 3 sessions
+        assert!(matches!(&app.filtered_rows[0], PickerRow::DateHeader(g) if g == "2026/05/08"));
+        assert!(matches!(app.filtered_rows[1], PickerRow::Session(0)));
+        assert!(matches!(&app.filtered_rows[2], PickerRow::DateHeader(g) if g == "2026/05/07"));
+    }
+
+    #[test]
+    fn rebuild_picker_rows_search_filters_and_skips_empty_groups() {
+        let mut sessions = vec![
+            sample_session_info("s1", "2026/05/08", "2026-05-08T00:00:00Z"),
+            sample_session_info("s2", "2026/05/07", "2026-05-07T00:00:00Z"),
+        ];
+        sessions[0].cwd = Some("/tmp/alpha".to_string());
+        sessions[1].cwd = Some("/tmp/beta".to_string());
+        let mut app = test_app(sessions);
+        app.search_query = "alpha".to_string();
+        app.rebuild_picker_rows();
+        // Only the alpha session's date group should survive.
+        assert_eq!(app.filtered_rows.len(), 2);
+        assert!(matches!(&app.filtered_rows[0], PickerRow::DateHeader(g) if g == "2026/05/08"));
+        assert!(matches!(app.filtered_rows[1], PickerRow::Session(0)));
+    }
+
+    #[test]
+    fn activate_picker_row_collapses_and_expands_a_group() {
+        let sessions = vec![sample_session_info(
+            "s1",
+            "2026/05/08",
+            "2026-05-08T00:00:00Z",
+        )];
+        let mut app = test_app(sessions);
+        app.picker_state.select(Some(0));
+        app.activate_picker_row();
+        assert_eq!(app.filtered_rows.len(), 1); // header only, session hidden
+        app.activate_picker_row();
+        assert_eq!(app.filtered_rows.len(), 2); // expanded again
+    }
+
+    #[test]
+    fn move_picker_clamps_at_list_bounds() {
+        let sessions = vec![
+            sample_session_info("s1", "2026/05/08", "2026-05-08T00:00:00Z"),
+            sample_session_info("s2", "2026/05/07", "2026-05-07T00:00:00Z"),
+        ];
+        let mut app = test_app(sessions);
+        app.picker_state.select(Some(0));
+        app.move_picker(-5);
+        assert_eq!(app.picker_state.selected(), Some(0));
+        app.move_picker(100);
+        assert_eq!(
+            app.picker_state.selected(),
+            Some(app.filtered_rows.len() - 1)
+        );
+    }
+
+    #[test]
+    fn search_mode_typing_filters_live_and_escape_clears() {
+        let mut sessions = vec![sample_session_info(
+            "s1",
+            "2026/05/08",
+            "2026-05-08T00:00:00Z",
+        )];
+        sessions[0].cwd = Some("/tmp/alpha".to_string());
+        let mut app = test_app(sessions);
+        app.search_mode = true;
+        app.on_key_picker(KeyCode::Char('z'));
+        app.on_key_picker(KeyCode::Char('z'));
+        assert_eq!(app.filtered_rows.len(), 0);
+        app.on_key_picker(KeyCode::Esc);
+        assert!(!app.search_mode);
+        assert!(app.search_query.is_empty());
+        assert_eq!(app.filtered_rows.len(), 2);
+    }
+
+    fn write_session_with_tool_call(dir: &std::path::Path) -> PathBuf {
+        let path = dir.join("rollout-2026-05-07T00-00-00-testsess.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-05-07T00:00:00Z","type":"session_meta","payload":{"id":"testsess","timestamp":"2026-05-07T00:00:00Z","cwd":"/tmp"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"Hello agent"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:03Z","type":"response_item","payload":{"type":"custom_tool_call","call_id":"call1","name":"apply_patch","input":"do the thing"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:04Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call1","output":"{\"output\":\"done\",\"metadata\":{\"exit_code\":0}}"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"Hi there","phase":"final_answer"}}"#,
+                r#"{"timestamp":"2026-05-07T00:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1746576006.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn build_rows_interleaves_user_message_tool_call_and_agent_message_in_order() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_tool_call(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let rows = build_rows(&session);
+        assert_eq!(
+            rows,
+            vec![
+                Row::TurnHeader(0),
+                Row::UserMessage(0),
+                Row::Tool(0, 0),
+                Row::Agent(0, 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn open_session_by_index_switches_to_detail_screen_and_builds_rows() {
+        let tmp = tempdir().unwrap();
+        write_session_with_tool_call(tmp.path());
+        let mut app = App::new(tmp.path().to_path_buf());
+        assert_eq!(app.sessions.len(), 1);
+        app.picker_state.select(Some(1)); // row 0 is the date header
+        app.activate_picker_row();
+        assert_eq!(app.screen, Screen::Detail);
+        assert_eq!(app.stack.len(), 1);
+        assert_eq!(app.stack[0].rows.len(), 4);
+    }
+
+    #[test]
+    fn toggle_expand_selected_only_affects_tool_rows() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_tool_call(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        // Row 1 is the user message — toggling should have no effect.
+        open.list_state.select(Some(1));
+        open.toggle_expand_selected();
+        assert!(open.expanded.is_empty());
+        // Row 2 is the tool call.
+        open.list_state.select(Some(2));
+        open.toggle_expand_selected();
+        assert!(open.expanded.contains(&(0, 0)));
+        open.toggle_expand_selected();
+        assert!(open.expanded.is_empty());
+    }
+
+    #[test]
+    fn set_all_expanded_expands_and_collapses_every_tool_call() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_tool_call(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.set_all_expanded(true);
+        assert_eq!(open.expanded.len(), 1);
+        open.set_all_expanded(false);
+        assert!(open.expanded.is_empty());
+    }
+
+    #[test]
+    fn on_key_detail_list_esc_pops_stack_back_to_picker() {
+        let tmp = tempdir().unwrap();
+        write_session_with_tool_call(tmp.path());
+        let mut app = App::new(tmp.path().to_path_buf());
+        app.picker_state.select(Some(1));
+        app.activate_picker_row();
+        assert_eq!(app.screen, Screen::Detail);
+        app.on_key(KeyCode::Esc, KeyModifiers::NONE);
+        assert!(app.stack.is_empty());
+        assert_eq!(app.screen, Screen::Picker);
+    }
+
+    #[test]
+    fn selected_worker_session_returns_none_for_non_spawn_tool() {
+        let tmp = tempdir().unwrap();
+        let path = write_session_with_tool_call(tmp.path());
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.list_state.select(Some(2)); // the custom tool call row
+        assert!(open.selected_worker_session().is_none());
+    }
+
+    #[test]
+    fn selected_worker_session_returns_embedded_session_for_spawn_agent() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-2026-04-27T16-50-45-parent.jsonl");
+        let worker_path = tmp
+            .path()
+            .join("rollout-2026-04-27T16-50-46-worker-session.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-04-27T04:50:45Z","type":"session_meta","payload":{"id":"parent","timestamp":"2026-04-27T04:50:45Z"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:02Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","arguments":"{\"agent_type\":\"worker\",\"message\":\"Collect evidence\"}","call_id":"call_spawn"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_spawn","output":"{\"agent_id\":\"worker-session\",\"nickname\":\"Parfit\"}"}}"#,
+                r#"{"timestamp":"2026-04-27T04:52:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1777279924.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            &worker_path,
+            r#"{"timestamp":"2026-04-27T04:50:46Z","type":"session_meta","payload":{"id":"worker-session","timestamp":"2026-04-27T04:50:46Z","cwd":"/tmp/worker"}}"#,
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        let mut open = OpenSession::new(session, path);
+        open.list_state.select(Some(1)); // the spawn_agent tool call row (no user message here)
+        let worker = open
+            .selected_worker_session()
+            .expect("worker session embedded");
+        assert_eq!(worker.id, "worker-session");
+    }
+}

--- a/src-tauri/src/tui/mod.rs
+++ b/src-tauri/src/tui/mod.rs
@@ -1,0 +1,67 @@
+mod app;
+mod ui;
+
+use std::io;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use ratatui::backend::CrosstermBackend;
+use ratatui::crossterm::event::{self, Event, KeyEventKind};
+use ratatui::crossterm::execute;
+use ratatui::crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::Terminal;
+
+use app::App;
+
+/// Run the terminal UI, blocking until the user quits.
+///
+/// Entirely bypasses Tauri/WebKit — invoked from `main.rs` via `codex-trace --tui`,
+/// the same way `--headless` skips window creation to run just the HTTP server.
+pub fn run_tui(sessions_dir: PathBuf) -> io::Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut app = App::new(sessions_dir);
+    let result = run_event_loop(&mut terminal, &mut app);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_event_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    app: &mut App,
+) -> io::Result<()> {
+    // Ticking at 500ms lets an ongoing session's rollout file be re-read and
+    // redrawn without a dedicated file-watcher thread; on_tick() only reparses
+    // when the file's mtime actually changed.
+    let tick_rate = Duration::from_millis(500);
+    let mut last_tick = Instant::now();
+    loop {
+        terminal.draw(|f| ui::draw(f, app))?;
+
+        let timeout = tick_rate.saturating_sub(last_tick.elapsed());
+        if event::poll(timeout)? {
+            if let Event::Key(key) = event::read()? {
+                if key.kind == KeyEventKind::Press {
+                    app.on_key(key.code, key.modifiers);
+                }
+            }
+        }
+        if last_tick.elapsed() >= tick_rate {
+            app.on_tick();
+            last_tick = Instant::now();
+        }
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}

--- a/src-tauri/src/tui/ui.rs
+++ b/src-tauri/src/tui/ui.rs
@@ -11,7 +11,7 @@ use crate::parser::session::CodexSession;
 use crate::parser::toolcall::{ToolCall, ToolKind};
 use crate::parser::turn::TurnStatus;
 
-use super::app::{App, DetailFocus, ItemPanel, OpenSession, PickerRow, Row, Screen};
+use super::app::{App, DetailFocus, GroupMode, ItemPanel, OpenSession, PickerRow, Row, Screen};
 
 pub fn draw(f: &mut Frame, app: &mut App) {
     match app.screen {
@@ -34,8 +34,12 @@ fn draw_picker(f: &mut Frame, app: &mut App) {
         ])
         .split(area);
 
+    let group_label = match app.group_mode {
+        GroupMode::Date => "by date",
+        GroupMode::Project => "by project",
+    };
     let title = format!(
-        " Codex Trace — {} ({} sessions) ",
+        " Codex Trace — {} ({} sessions, {group_label}) ",
         app.sessions_dir.display(),
         app.sessions.len()
     );
@@ -59,7 +63,7 @@ fn draw_picker(f: &mut Frame, app: &mut App) {
     let footer_text = if app.search_mode {
         format!("search: {}_", app.search_query)
     } else {
-        "j/k move   Enter open/toggle   /  search   r  refresh   ?  help   q  quit".to_string()
+        "j/k move   Enter open/toggle   /  search   p  group by date/project   r  refresh   ?  help   q  quit".to_string()
     };
     let footer = Paragraph::new(footer_text).style(Style::default().fg(Color::Gray));
     f.render_widget(footer, chunks[2]);
@@ -74,7 +78,7 @@ fn picker_items(app: &App) -> Vec<ListItem<'static>> {
 
 fn picker_row_item(app: &App, row: &PickerRow) -> ListItem<'static> {
     match row {
-        PickerRow::DateHeader(group) => {
+        PickerRow::DateHeader(group) | PickerRow::ProjectHeader(group) => {
             let collapsed = app.collapsed_groups.contains(group);
             let arrow = if collapsed { "▶" } else { "▼" };
             ListItem::new(Line::from(Span::styled(
@@ -140,6 +144,7 @@ fn draw_detail(f: &mut Frame, app: &mut App) {
     match open.focus {
         DetailFocus::List => draw_detail_list(f, open, depth),
         DetailFocus::Item => draw_detail_item(f, open),
+        DetailFocus::Team => draw_detail_team(f, open),
     }
 }
 
@@ -184,10 +189,109 @@ fn draw_detail_list(f: &mut Frame, open: &mut OpenSession, depth: usize) {
     f.render_stateful_widget(list, chunks[1], &mut open.list_state);
 
     let footer = Paragraph::new(
-        "j/k move   Tab expand   e/c expand/collapse all   Enter detail   r refresh   Esc back   ? help",
+        "j/k move   Tab expand   e/c expand/collapse all   Enter detail   t team   r refresh   Esc back   ? help",
     )
     .style(Style::default().fg(Color::Gray));
     f.render_widget(footer, chunks[2]);
+}
+
+/// Roster of every `spawn_agent` call in the session, flattened across turns
+/// — the terminal equivalent of the web/TUI reference's `TeamBoard`.
+fn draw_detail_team(f: &mut Frame, open: &mut OpenSession) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let header = Paragraph::new(info_bar_line(&open.session)).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} — Team ", open.session.id)),
+    );
+    f.render_widget(header, chunks[0]);
+
+    let rows = open.team_rows();
+    let items: Vec<ListItem<'static>> = if rows.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "No spawned agents in this session",
+            Style::default().fg(Color::DarkGray),
+        )))]
+    } else {
+        rows.iter()
+            .map(|(t, tc)| team_row_item(&open.session, *t, *tc))
+            .collect()
+    };
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(" Agents "))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+    f.render_stateful_widget(list, chunks[1], &mut open.team_state);
+
+    let footer = Paragraph::new("j/k move   Enter open worker session   Esc/t back   ? help")
+        .style(Style::default().fg(Color::Gray));
+    f.render_widget(footer, chunks[2]);
+}
+
+fn team_row_item(session: &CodexSession, t: usize, tc: usize) -> ListItem<'static> {
+    let turn = &session.turns[t];
+    let tool = &turn.tool_calls[tc];
+    let spawn = turn
+        .collab_spawns
+        .iter()
+        .find(|s| s.call_id == tool.call_id);
+
+    let nickname = spawn
+        .map(|s| s.agent_nickname.clone())
+        .or_else(|| tool.subagent_name.clone())
+        .unwrap_or_else(|| "(unnamed)".to_string());
+    let role = spawn.map(|s| s.agent_role.clone()).unwrap_or_default();
+    let model = spawn
+        .and_then(|s| s.model.clone())
+        .unwrap_or_else(|| "-".to_string());
+    let status_style = Style::default().fg(tool_status_color(&tool.status));
+
+    let mut spans = vec![
+        Span::styled(
+            format!("Turn {} ", t + 1),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled(nickname, Style::default().add_modifier(Modifier::BOLD)),
+    ];
+    if !role.is_empty() {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            format!("[{role}]"),
+            Style::default().fg(Color::Magenta),
+        ));
+    }
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(model, Style::default().fg(Color::Cyan)));
+    spans.push(Span::raw("  "));
+    spans.push(Span::styled(tool.status.clone(), status_style));
+    if tool.worker_session.is_some() {
+        spans.push(Span::styled(
+            "  ↳ Enter to open",
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    let mut lines = vec![Line::from(spans)];
+    if let Some(spawn) = spawn {
+        if !spawn.prompt_preview.is_empty() {
+            lines.push(Line::from(Span::raw(format!(
+                "    {}",
+                truncate(&single_line(&spawn.prompt_preview), 110)
+            ))));
+        }
+    }
+    ListItem::new(lines)
 }
 
 fn detail_items(open: &OpenSession) -> Vec<ListItem<'static>> {
@@ -706,8 +810,9 @@ fn draw_help(f: &mut Frame, screen: Screen) {
             "Session Picker",
             "",
             "j / k / ↑ / ↓   move selection",
-            "Enter / Space   open session, or expand/collapse a date group",
+            "Enter / Space   open session, or expand/collapse a group",
             "/               search sessions   (Esc clears, Enter keeps filter)",
+            "p               toggle grouping: by date / by project (cwd)",
             "r               rescan the sessions directory",
             "?               toggle this help",
             "q / Ctrl+C      quit",
@@ -720,6 +825,7 @@ fn draw_help(f: &mut Frame, screen: Screen) {
             "e / c                expand / collapse all tool calls",
             "Enter                open full detail, or drill into a spawned agent",
             "h / l                switch Request / Response panel in detail view",
+            "t                    team board — roster of spawned agents",
             "r                    reload the session from disk",
             "Esc / q              back to the list, or back to the picker",
             "?                    toggle this help",

--- a/src-tauri/src/tui/ui.rs
+++ b/src-tauri/src/tui/ui.rs
@@ -1,12 +1,14 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
+use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
 
+use crate::parser::diff::{DiffLine, DiffLineKind};
 use crate::parser::discover::CodexSessionInfo;
+use crate::parser::patch::{parse_apply_patch, PatchFile, PatchFileOp};
 use crate::parser::session::CodexSession;
-use crate::parser::toolcall::ToolCall;
+use crate::parser::toolcall::{ToolCall, ToolKind};
 use crate::parser::turn::TurnStatus;
 
 use super::app::{App, DetailFocus, ItemPanel, OpenSession, PickerRow, Row, Screen};
@@ -167,7 +169,8 @@ fn draw_detail_list(f: &mut Frame, open: &mut OpenSession, depth: usize) {
         session.turns.len(),
         session.cwd.clone().unwrap_or_default()
     );
-    let header = Paragraph::new("").block(Block::default().borders(Borders::ALL).title(title));
+    let header = Paragraph::new(info_bar_line(session))
+        .block(Block::default().borders(Borders::ALL).title(title));
     f.render_widget(header, chunks[0]);
 
     let items = detail_items(open);
@@ -336,7 +339,7 @@ fn draw_detail_item(f: &mut Frame, open: &OpenSession) {
         ])
         .split(area);
 
-    let header = Paragraph::new("").block(
+    let header = Paragraph::new(info_bar_line(&open.session)).block(
         Block::default()
             .borders(Borders::ALL)
             .title(format!(" {} ", content.heading)),
@@ -375,8 +378,8 @@ fn draw_detail_item(f: &mut Frame, open: &OpenSession) {
 struct ItemContent {
     heading: String,
     primary_title: String,
-    primary: String,
-    secondary: Option<(String, String)>,
+    primary: Text<'static>,
+    secondary: Option<(String, Text<'static>)>,
 }
 
 fn item_content(session: &CodexSession, row: Row) -> ItemContent {
@@ -385,7 +388,7 @@ fn item_content(session: &CodexSession, row: Row) -> ItemContent {
         Row::UserMessage(t) => ItemContent {
             heading: format!("Turn {} — User Message", t + 1),
             primary_title: "Message".to_string(),
-            primary: session.turns[t].user_message.clone().unwrap_or_default(),
+            primary: Text::raw(session.turns[t].user_message.clone().unwrap_or_default()),
             secondary: None,
         },
         Row::Agent(t, m) => {
@@ -403,7 +406,7 @@ fn item_content(session: &CodexSession, row: Row) -> ItemContent {
             ItemContent {
                 heading: format!("Turn {} — {kind}{phase}", t + 1),
                 primary_title: kind.to_string(),
-                primary: msg.text.clone(),
+                primary: Text::raw(msg.text.clone()),
                 secondary: None,
             }
         }
@@ -482,7 +485,7 @@ fn turn_item_content(session: &CodexSession, t: usize) -> ItemContent {
     ItemContent {
         heading: format!("Turn {}", t + 1),
         primary_title: "Details".to_string(),
-        primary: lines.join("\n"),
+        primary: Text::raw(lines.join("\n")),
         secondary: None,
     }
 }
@@ -520,14 +523,12 @@ fn tool_item_content(session: &CodexSession, t: usize, tc: usize) -> ItemContent
     if let Some(name) = &tool.subagent_name {
         req.push(format!("subagent_name: {name}"));
     }
-    if let Some(text) = &tool.input_text {
-        req.push(String::new());
-        req.push("input:".to_string());
-        req.push(text.clone());
-    } else if let Some(pretty) = pretty_json(&tool.arguments) {
-        req.push(String::new());
-        req.push("arguments:".to_string());
-        req.push(pretty);
+
+    let mut primary_lines: Vec<Line<'static>> = req.into_iter().map(Line::raw).collect();
+    let body = tool_body_lines(tool);
+    if !body.is_empty() {
+        primary_lines.push(Line::default());
+        primary_lines.extend(body);
     }
 
     let mut resp = vec![format!("status: {}", tool.status)];
@@ -569,9 +570,132 @@ fn tool_item_content(session: &CodexSession, t: usize, tc: usize) -> ItemContent
     ItemContent {
         heading: format!("Turn {} — {}", t + 1, tool.name),
         primary_title: "Request".to_string(),
-        primary: req.join("\n"),
-        secondary: Some(("Response".to_string(), resp.join("\n"))),
+        primary: Text::from(primary_lines),
+        secondary: Some(("Response".to_string(), Text::raw(resp.join("\n")))),
     }
+}
+
+/// Body of the Request panel: a structured red/green diff for `apply_patch`
+/// calls (mirroring the web frontend's `PatchDiff`/`DiffLines`), falling back
+/// to a plain `patch_changes.unified_diff` dump and then to the raw input
+/// text when the body isn't a recognisable patch. Non-patch tool calls just
+/// get their input/arguments dumped as before.
+fn tool_body_lines(tool: &ToolCall) -> Vec<Line<'static>> {
+    if tool.kind == ToolKind::PatchApply {
+        if let Some(text) = &tool.input_text {
+            if let Some(files) = parse_apply_patch(text) {
+                return render_patch_diff(&files);
+            }
+        }
+        if let Some(changes) = &tool.patch_changes {
+            let lines = render_patch_changes_fallback(changes);
+            if !lines.is_empty() {
+                return lines;
+            }
+        }
+    }
+    if let Some(text) = &tool.input_text {
+        let mut lines = vec![Line::raw("input:")];
+        lines.extend(text.lines().map(|l| Line::raw(l.to_string())));
+        lines
+    } else if let Some(pretty) = pretty_json(&tool.arguments) {
+        let mut lines = vec![Line::raw("arguments:")];
+        lines.extend(pretty.lines().map(|l| Line::raw(l.to_string())));
+        lines
+    } else {
+        Vec::new()
+    }
+}
+
+fn patch_op_label_color(op: PatchFileOp) -> (&'static str, Color) {
+    match op {
+        PatchFileOp::Add => ("add", Color::Green),
+        PatchFileOp::Update => ("update", Color::Yellow),
+        PatchFileOp::Delete => ("delete", Color::Red),
+    }
+}
+
+/// Render parsed patch files as per-file, per-hunk diff lines with +/-
+/// markers, red/green line tinting, and bold+underline on word-level changed
+/// spans — the terminal equivalent of the web UI's `PatchDiff`/`DiffLines`.
+fn render_patch_diff(files: &[PatchFile]) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for file in files {
+        let (op_label, op_color) = patch_op_label_color(file.op);
+        let mut header = vec![
+            Span::styled(
+                format!("[{op_label}] "),
+                Style::default().fg(op_color).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(file.path.clone(), Style::default().fg(Color::Cyan)),
+        ];
+        if let Some(mv) = &file.move_path {
+            header.push(Span::raw(format!(" → {mv}")));
+        }
+        lines.push(Line::from(header));
+        for hunk in &file.hunks {
+            if !hunk.header.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    format!("@@ {}", hunk.header),
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+            lines.extend(hunk.lines.iter().map(diff_line_to_line));
+        }
+        lines.push(Line::default());
+    }
+    lines
+}
+
+fn diff_line_to_line(dl: &DiffLine) -> Line<'static> {
+    let (marker, base_color) = match dl.kind {
+        DiffLineKind::Context => (" ", Color::DarkGray),
+        DiffLineKind::Removed => ("-", Color::Red),
+        DiffLineKind::Added => ("+", Color::Green),
+    };
+    let mut spans = vec![Span::styled(marker, Style::default().fg(base_color))];
+    for seg in &dl.segments {
+        let style = if seg.changed {
+            Style::default()
+                .fg(base_color)
+                .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+        } else {
+            Style::default().fg(base_color)
+        };
+        spans.push(Span::styled(seg.text.clone(), style));
+    }
+    Line::from(spans)
+}
+
+/// Plain (uncoloured) per-file dump of `tool.patch_changes` for when the raw
+/// patch body wasn't parseable — mirrors the web UI's fallback view.
+fn render_patch_changes_fallback(changes: &serde_json::Value) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let Some(map) = changes.as_object() else {
+        return lines;
+    };
+    for (file, change) in map {
+        let change_type = change
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("update");
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("[{change_type}] "),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(file.clone(), Style::default().fg(Color::Cyan)),
+        ]));
+        if let Some(diff_text) = change.get("unified_diff").and_then(|v| v.as_str()) {
+            lines.extend(diff_text.lines().map(|l| Line::raw(l.to_string())));
+        } else if let Some(content) = change.get("content").and_then(|v| v.as_str()) {
+            lines.extend(content.lines().map(|l| Line::raw(l.to_string())));
+        }
+        lines.push(Line::default());
+    }
+    lines
 }
 
 fn draw_help(f: &mut Frame, screen: Screen) {
@@ -625,6 +749,84 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(vertical[1])[1]
+}
+
+/// Persistent status line shown under the panel title on every Detail
+/// screen: git branch · model · context-window usage (color-coded) · token
+/// count — the terminal equivalent of the web/TUI reference's `InfoBar`.
+fn info_bar_line(session: &CodexSession) -> Line<'static> {
+    let dim = Style::default().fg(Color::DarkGray);
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let push_field = |spans: &mut Vec<Span<'static>>, span: Span<'static>| {
+        if !spans.is_empty() {
+            spans.push(Span::styled(" · ", dim));
+        }
+        spans.push(span);
+    };
+
+    if let Some(branch) = session.git.as_ref().and_then(|g| g.branch.as_deref()) {
+        push_field(
+            &mut spans,
+            Span::styled(format!("* {branch}"), Style::default().fg(Color::Magenta)),
+        );
+    }
+    if let Some(model) = last_turn_model(session) {
+        push_field(
+            &mut spans,
+            Span::styled(model, Style::default().fg(Color::Cyan)),
+        );
+    }
+    if let Some((pct, used, window)) = last_context_usage(session) {
+        push_field(
+            &mut spans,
+            Span::styled(
+                format!("ctx {pct}%"),
+                Style::default().fg(context_color(pct)),
+            ),
+        );
+        push_field(
+            &mut spans,
+            Span::styled(
+                format!("{}/{} tok", format_count(used), format_count(window)),
+                dim,
+            ),
+        );
+    }
+    if spans.is_empty() {
+        spans.push(Span::styled("(no session metadata)", dim));
+    }
+    Line::from(spans)
+}
+
+fn context_color(pct: u8) -> Color {
+    if pct < 50 {
+        Color::Green
+    } else if pct <= 80 {
+        Color::Yellow
+    } else {
+        Color::Red
+    }
+}
+
+fn last_turn_model(session: &CodexSession) -> Option<String> {
+    session.turns.iter().rev().find_map(|t| t.model.clone())
+}
+
+/// Context-window usage from the most recent turn that reported one — the
+/// running KV-cache state, not the session-wide token total.
+fn last_context_usage(session: &CodexSession) -> Option<(u8, u64, u64)> {
+    session.turns.iter().rev().find_map(|t| {
+        let info = t.total_tokens.as_ref()?;
+        let used = info.context_window_tokens?;
+        let window = info.model_context_window;
+        if window == 0 {
+            return None;
+        }
+        let pct = ((used as f64 / window as f64) * 100.0)
+            .round()
+            .clamp(0.0, 100.0) as u8;
+        Some((pct, used, window))
+    })
 }
 
 fn turn_status_color(status: &TurnStatus) -> Color {
@@ -711,5 +913,164 @@ fn truncate(s: &str, max: usize) -> String {
         let mut t: String = s.chars().take(max.saturating_sub(1)).collect();
         t.push('…');
         t
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patch_tool_call(
+        input_text: Option<&str>,
+        patch_changes: Option<serde_json::Value>,
+    ) -> ToolCall {
+        ToolCall {
+            call_id: "call1".to_string(),
+            kind: ToolKind::PatchApply,
+            name: "apply_patch".to_string(),
+            arguments: serde_json::Value::Null,
+            input_text: input_text.map(str::to_string),
+            output: None,
+            exit_code: None,
+            command: None,
+            cwd: None,
+            duration_secs: None,
+            mcp_server: None,
+            mcp_tool: None,
+            plugin_id: None,
+            patch_success: None,
+            patch_changes,
+            web_query: None,
+            web_url: None,
+            image_prompt: None,
+            image_file_path: None,
+            worker_session: None,
+            status: "success".to_string(),
+            subagent_id: None,
+            subagent_name: None,
+        }
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn tool_body_lines_renders_a_parseable_patch_as_a_colored_diff() {
+        let patch = [
+            "*** Begin Patch",
+            "*** Update File: src/main.rs",
+            "@@",
+            "-    println!(\"old\");",
+            "+    println!(\"new\");",
+            "*** End Patch",
+        ]
+        .join("\n");
+        let tool = patch_tool_call(Some(&patch), None);
+        let lines = tool_body_lines(&tool);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(texts.iter().any(|t| t.contains("[update] src/main.rs")));
+        assert!(texts.iter().any(|t| t.contains("-    println!(\"old\");")));
+        assert!(texts.iter().any(|t| t.contains("+    println!(\"new\");")));
+        // The changed word should carry a distinct (bold+underlined) style
+        // from the rest of the line, not just plain text.
+        let added_line = lines
+            .iter()
+            .find(|l| line_text(l).contains("println!(\"new\");"))
+            .expect("added line present");
+        assert!(added_line
+            .spans
+            .iter()
+            .any(|s| s.style.add_modifier.contains(Modifier::BOLD)));
+    }
+
+    #[test]
+    fn tool_body_lines_falls_back_to_patch_changes_unified_diff_when_input_is_not_a_patch() {
+        let changes = serde_json::json!({
+            "src/main.rs": { "type": "update", "unified_diff": "-old\n+new" }
+        });
+        let tool = patch_tool_call(Some("not a patch body"), Some(changes));
+        let lines = tool_body_lines(&tool);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert!(texts.iter().any(|t| t.contains("[update] src/main.rs")));
+        assert!(texts.iter().any(|t| t == "-old"));
+        assert!(texts.iter().any(|t| t == "+new"));
+    }
+
+    #[test]
+    fn tool_body_lines_falls_back_to_raw_input_text_when_nothing_is_parseable() {
+        let tool = patch_tool_call(Some("just some output text"), None);
+        let lines = tool_body_lines(&tool);
+        let texts: Vec<String> = lines.iter().map(line_text).collect();
+        assert_eq!(
+            texts,
+            vec!["input:".to_string(), "just some output text".to_string()]
+        );
+    }
+
+    #[test]
+    fn context_color_is_green_below_50_yellow_in_band_red_above_80() {
+        assert_eq!(context_color(0), Color::Green);
+        assert_eq!(context_color(49), Color::Green);
+        assert_eq!(context_color(50), Color::Yellow);
+        assert_eq!(context_color(80), Color::Yellow);
+        assert_eq!(context_color(81), Color::Red);
+        assert_eq!(context_color(100), Color::Red);
+    }
+
+    fn write_session_with_git_and_context(dir: &std::path::Path) -> std::path::PathBuf {
+        let path = dir.join("rollout-2026-06-01T00-00-00-infobar.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"infobar","timestamp":"2026-06-01T00:00:00Z","cwd":"/tmp/my-project","git":{"branch":"feature/x"}}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:02Z","type":"turn_context","payload":{"model":"gpt-5.4","cwd":"/tmp/my-project"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0,"total_tokens":2},"last_token_usage":{"input_tokens":40000,"cached_input_tokens":10000,"output_tokens":1000,"reasoning_output_tokens":0,"total_tokens":51000},"model_context_window":100000}}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1780357204.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn info_bar_line_shows_branch_model_and_context_percent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = write_session_with_git_and_context(tmp.path());
+        let session = crate::parser::session::parse_session(&path).unwrap();
+
+        assert_eq!(last_context_usage(&session), Some((51, 51_000, 100_000)));
+        let line = info_bar_line(&session);
+        let text = line_text(&line);
+        assert!(text.contains("* feature/x"), "expected branch in {text:?}");
+        assert!(text.contains("gpt-5.4"), "expected model in {text:?}");
+        assert!(text.contains("ctx 51%"), "expected context pct in {text:?}");
+    }
+
+    #[test]
+    fn info_bar_line_placeholder_when_session_has_no_metadata() {
+        let session = crate::parser::session::CodexSession {
+            id: "bare".to_string(),
+            timestamp: String::new(),
+            cwd: None,
+            originator: None,
+            cli_version: None,
+            model_provider: None,
+            git: None,
+            instructions: None,
+            turns: Vec::new(),
+            is_ongoing: false,
+            total_tokens: None,
+            thread_name: None,
+            spawned_worker_ids: Vec::new(),
+            path: String::new(),
+            ai_title: None,
+            is_headless: false,
+            has_missing_spawn_metadata: false,
+        };
+        let text = line_text(&info_bar_line(&session));
+        assert_eq!(text, "(no session metadata)");
     }
 }

--- a/src-tauri/src/tui/ui.rs
+++ b/src-tauri/src/tui/ui.rs
@@ -1,0 +1,715 @@
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap};
+use ratatui::Frame;
+
+use crate::parser::discover::CodexSessionInfo;
+use crate::parser::session::CodexSession;
+use crate::parser::toolcall::ToolCall;
+use crate::parser::turn::TurnStatus;
+
+use super::app::{App, DetailFocus, ItemPanel, OpenSession, PickerRow, Row, Screen};
+
+pub fn draw(f: &mut Frame, app: &mut App) {
+    match app.screen {
+        Screen::Picker => draw_picker(f, app),
+        Screen::Detail => draw_detail(f, app),
+    }
+    if app.show_help {
+        draw_help(f, app.screen);
+    }
+}
+
+fn draw_picker(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let title = format!(
+        " Codex Trace — {} ({} sessions) ",
+        app.sessions_dir.display(),
+        app.sessions.len()
+    );
+    let header_text = app.status_message.clone().unwrap_or_default();
+    let header = Paragraph::new(header_text)
+        .style(Style::default().fg(Color::Red))
+        .block(Block::default().borders(Borders::ALL).title(title));
+    f.render_widget(header, chunks[0]);
+
+    let items = picker_items(app);
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(" Sessions "))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("➤ ");
+    f.render_stateful_widget(list, chunks[1], &mut app.picker_state);
+
+    let footer_text = if app.search_mode {
+        format!("search: {}_", app.search_query)
+    } else {
+        "j/k move   Enter open/toggle   /  search   r  refresh   ?  help   q  quit".to_string()
+    };
+    let footer = Paragraph::new(footer_text).style(Style::default().fg(Color::Gray));
+    f.render_widget(footer, chunks[2]);
+}
+
+fn picker_items(app: &App) -> Vec<ListItem<'static>> {
+    app.filtered_rows
+        .iter()
+        .map(|row| picker_row_item(app, row))
+        .collect()
+}
+
+fn picker_row_item(app: &App, row: &PickerRow) -> ListItem<'static> {
+    match row {
+        PickerRow::DateHeader(group) => {
+            let collapsed = app.collapsed_groups.contains(group);
+            let arrow = if collapsed { "▶" } else { "▼" };
+            ListItem::new(Line::from(Span::styled(
+                format!("{arrow} {group}"),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )))
+        }
+        PickerRow::Session(idx) => session_list_item(&app.sessions[*idx]),
+    }
+}
+
+fn session_list_item(s: &CodexSessionInfo) -> ListItem<'static> {
+    let status_style = if s.is_ongoing {
+        Style::default().fg(Color::Green)
+    } else if s.is_archived {
+        Style::default().fg(Color::DarkGray)
+    } else {
+        Style::default()
+    };
+    let status = if s.is_ongoing { "●" } else { " " };
+    let prefix = if s.is_inline_worker { "  ↳ " } else { "    " };
+    let title = s
+        .ai_title
+        .clone()
+        .or_else(|| s.thread_name.clone())
+        .or_else(|| s.cwd.clone())
+        .unwrap_or_else(|| s.id.clone());
+    let title = truncate(&single_line(&title), 48);
+    let model = s.model.clone().unwrap_or_else(|| "-".to_string());
+    let tokens = s
+        .total_tokens
+        .map(format_count)
+        .unwrap_or_else(|| "-".to_string());
+    let time = fmt_iso(&Some(s.start_time.clone()));
+
+    let mut spans = vec![
+        Span::styled(status, status_style),
+        Span::raw(prefix),
+        Span::styled(title, Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("  "),
+        Span::styled(model, Style::default().fg(Color::Cyan)),
+        Span::raw(format!(
+            "   {} turns   {} tok   {}",
+            s.turn_count, tokens, time
+        )),
+    ];
+    if let Some(role) = &s.worker_role {
+        spans.push(Span::styled(
+            format!("  [{role}]"),
+            Style::default().fg(Color::Magenta),
+        ));
+    }
+    ListItem::new(Line::from(spans))
+}
+
+fn draw_detail(f: &mut Frame, app: &mut App) {
+    let depth = app.stack.len();
+    let Some(open) = app.stack.last_mut() else {
+        return;
+    };
+    match open.focus {
+        DetailFocus::List => draw_detail_list(f, open, depth),
+        DetailFocus::Item => draw_detail_item(f, open),
+    }
+}
+
+fn draw_detail_list(f: &mut Frame, open: &mut OpenSession, depth: usize) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let session = &open.session;
+    let breadcrumb = if depth > 1 {
+        format!("  (worker depth {depth})")
+    } else {
+        String::new()
+    };
+    let live = if session.is_ongoing { "  ● LIVE" } else { "" };
+    let title = format!(
+        " {}{}{}   {} turns   {} ",
+        session.id,
+        breadcrumb,
+        live,
+        session.turns.len(),
+        session.cwd.clone().unwrap_or_default()
+    );
+    let header = Paragraph::new("").block(Block::default().borders(Borders::ALL).title(title));
+    f.render_widget(header, chunks[0]);
+
+    let items = detail_items(open);
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title(" Turns "))
+        .highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        );
+    f.render_stateful_widget(list, chunks[1], &mut open.list_state);
+
+    let footer = Paragraph::new(
+        "j/k move   Tab expand   e/c expand/collapse all   Enter detail   r refresh   Esc back   ? help",
+    )
+    .style(Style::default().fg(Color::Gray));
+    f.render_widget(footer, chunks[2]);
+}
+
+fn detail_items(open: &OpenSession) -> Vec<ListItem<'static>> {
+    open.rows
+        .iter()
+        .map(|row| detail_row_item(&open.session, *row, open.expanded.contains(&tool_key(*row))))
+        .collect()
+}
+
+fn tool_key(row: Row) -> (usize, usize) {
+    match row {
+        Row::Tool(t, tc) => (t, tc),
+        _ => (usize::MAX, usize::MAX),
+    }
+}
+
+fn detail_row_item(session: &CodexSession, row: Row, expanded: bool) -> ListItem<'static> {
+    match row {
+        Row::TurnHeader(t) => turn_header_item(session, t),
+        Row::UserMessage(t) => user_message_item(session, t),
+        Row::Agent(t, m) => agent_item(session, t, m),
+        Row::Tool(t, tc) => tool_item(session, t, tc, expanded),
+    }
+}
+
+fn turn_header_item(session: &CodexSession, t: usize) -> ListItem<'static> {
+    let turn = &session.turns[t];
+    let status = format!("{:?}", turn.status);
+    let color = turn_status_color(&turn.status);
+    let model = turn.model.clone().unwrap_or_else(|| "-".to_string());
+    let dur = fmt_duration_ms(turn.duration_ms);
+    let tokens = turn
+        .total_tokens
+        .as_ref()
+        .map(|ti| format_count(ti.total_tokens))
+        .unwrap_or_else(|| "-".to_string());
+    let line = Line::from(vec![
+        Span::styled(
+            format!("▶ Turn {} ", t + 1),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(status, Style::default().fg(color)),
+        Span::raw(format!("   {model}   {dur}   {tokens} tok")),
+    ]);
+    ListItem::new(line)
+}
+
+fn user_message_item(session: &CodexSession, t: usize) -> ListItem<'static> {
+    let text = session.turns[t].user_message.clone().unwrap_or_default();
+    let preview = truncate(&single_line(&text), 110);
+    ListItem::new(Line::from(vec![
+        Span::styled(
+            "   user  ",
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(preview),
+    ]))
+}
+
+fn agent_item(session: &CodexSession, t: usize, m: usize) -> ListItem<'static> {
+    let msg = &session.turns[t].agent_messages[m];
+    let (label, color) = if msg.is_reasoning {
+        ("reason", Color::DarkGray)
+    } else {
+        ("agent ", Color::White)
+    };
+    let preview = truncate(&single_line(&msg.text), 110);
+    ListItem::new(Line::from(vec![
+        Span::styled(format!("   {label} "), Style::default().fg(color)),
+        Span::raw(preview),
+    ]))
+}
+
+fn tool_item(session: &CodexSession, t: usize, tc: usize, expanded: bool) -> ListItem<'static> {
+    let tool = &session.turns[t].tool_calls[tc];
+    let arrow = if expanded { "▾" } else { "▸" };
+    let status_style = Style::default().fg(tool_status_color(&tool.status));
+    let mut lines = vec![Line::from(vec![
+        Span::raw(format!("   {arrow} ")),
+        Span::styled(
+            format!("{:?} ", tool.kind),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::styled(
+            tool.name.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("   "),
+        Span::styled(tool.status.clone(), status_style),
+        Span::raw(
+            tool.duration_secs
+                .map(|d| format!("   {d:.1}s"))
+                .unwrap_or_default(),
+        ),
+    ])];
+    if expanded {
+        for l in tool_preview_lines(tool) {
+            lines.push(Line::from(Span::raw(format!("       {l}"))));
+        }
+    }
+    ListItem::new(lines)
+}
+
+fn tool_preview_lines(tool: &ToolCall) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(cmd) = &tool.command {
+        out.push(format!("$ {}", cmd.join(" ")));
+    }
+    if let Some(text) = &tool.input_text {
+        out.push(format!("in:   {}", truncate(&single_line(text), 100)));
+    } else if let Some(pretty) = pretty_json(&tool.arguments) {
+        out.push(format!("args: {}", truncate(&single_line(&pretty), 100)));
+    }
+    if let Some(output) = &tool.output {
+        out.push(format!("out:  {}", truncate(&single_line(output), 100)));
+    }
+    if let Some(worker) = &tool.worker_session {
+        out.push(format!(
+            "worker session {} ({} turns) — press Enter to open",
+            worker.id,
+            worker.turns.len()
+        ));
+    }
+    if out.is_empty() {
+        out.push("(no preview — press Enter for full detail)".to_string());
+    } else {
+        out.push("press Enter for full detail".to_string());
+    }
+    out
+}
+
+fn draw_detail_item(f: &mut Frame, open: &OpenSession) {
+    let area = f.area();
+    let Some(row) = open.selected_row() else {
+        return;
+    };
+    let content = item_content(&open.session, row);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let header = Paragraph::new("").block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {} ", content.heading)),
+    );
+    f.render_widget(header, chunks[0]);
+
+    let (panel_title, text) = match (open.item_panel, &content.secondary) {
+        (ItemPanel::Secondary, Some((title, text))) => (title.clone(), text.clone()),
+        _ => (content.primary_title.clone(), content.primary.clone()),
+    };
+    let tabs_title = if let Some((sec_title, _)) = &content.secondary {
+        let active = if open.item_panel == ItemPanel::Primary {
+            &content.primary_title
+        } else {
+            sec_title
+        };
+        format!(
+            " {} / {}   (showing: {}, h/l to switch) ",
+            content.primary_title, sec_title, active
+        )
+    } else {
+        format!(" {panel_title} ")
+    };
+
+    let body = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).title(tabs_title))
+        .wrap(Wrap { trim: false })
+        .scroll((open.item_scroll, 0));
+    f.render_widget(body, chunks[1]);
+
+    let footer = Paragraph::new("h/l switch panel   j/k scroll   Esc/Enter back   ? help")
+        .style(Style::default().fg(Color::Gray));
+    f.render_widget(footer, chunks[2]);
+}
+
+struct ItemContent {
+    heading: String,
+    primary_title: String,
+    primary: String,
+    secondary: Option<(String, String)>,
+}
+
+fn item_content(session: &CodexSession, row: Row) -> ItemContent {
+    match row {
+        Row::TurnHeader(t) => turn_item_content(session, t),
+        Row::UserMessage(t) => ItemContent {
+            heading: format!("Turn {} — User Message", t + 1),
+            primary_title: "Message".to_string(),
+            primary: session.turns[t].user_message.clone().unwrap_or_default(),
+            secondary: None,
+        },
+        Row::Agent(t, m) => {
+            let msg = &session.turns[t].agent_messages[m];
+            let kind = if msg.is_reasoning {
+                "Reasoning"
+            } else {
+                "Agent Message"
+            };
+            let phase = msg
+                .phase
+                .as_deref()
+                .map(|p| format!(" ({p})"))
+                .unwrap_or_default();
+            ItemContent {
+                heading: format!("Turn {} — {kind}{phase}", t + 1),
+                primary_title: kind.to_string(),
+                primary: msg.text.clone(),
+                secondary: None,
+            }
+        }
+        Row::Tool(t, tc) => tool_item_content(session, t, tc),
+    }
+}
+
+fn turn_item_content(session: &CodexSession, t: usize) -> ItemContent {
+    let turn = &session.turns[t];
+    let mut lines = vec![
+        format!("turn_id: {}", turn.turn_id),
+        format!("status: {:?}", turn.status),
+        format!(
+            "model: {}",
+            turn.model.clone().unwrap_or_else(|| "-".into())
+        ),
+        format!("cwd: {}", turn.cwd.clone().unwrap_or_else(|| "-".into())),
+        format!(
+            "reasoning_effort: {}",
+            turn.reasoning_effort.clone().unwrap_or_else(|| "-".into())
+        ),
+        format!("started: {}", fmt_epoch(turn.started_at)),
+        format!("completed: {}", fmt_epoch(turn.completed_at)),
+        format!("duration: {}", fmt_duration_ms(turn.duration_ms)),
+    ];
+    if let Some(tokens) = &turn.total_tokens {
+        lines.push(format!(
+            "tokens: input={} cached={} output={} reasoning={} total={}",
+            tokens.input_tokens,
+            tokens.cached_input_tokens,
+            tokens.output_tokens,
+            tokens.reasoning_output_tokens,
+            tokens.total_tokens
+        ));
+    }
+    if let Some(err) = &turn.error {
+        lines.push(format!("error: {err}"));
+    }
+    if let Some(reason) = &turn.aborted_reason {
+        lines.push(format!("aborted_reason: {reason}"));
+    }
+    if turn.has_compaction {
+        lines.push("compaction: yes".to_string());
+        if let Some(meta) = &turn.compaction_meta {
+            lines.push(format!(
+                "  tokens_before={:?} tokens_after={:?} trigger={:?}",
+                meta.tokens_before, meta.tokens_after, meta.compaction_trigger
+            ));
+            if let Some(summary) = &meta.summary {
+                lines.push(format!("  summary: {summary}"));
+            }
+        }
+    }
+    if !turn.memories.is_empty() {
+        lines.push(format!("memories: {}", turn.memories.len()));
+        for m in &turn.memories {
+            lines.push(format!("  - {}", single_line(&m.content)));
+        }
+    }
+    if !turn.collab_spawns.is_empty() {
+        lines.push("spawned agents:".to_string());
+        for spawn in &turn.collab_spawns {
+            lines.push(format!(
+                "  - {} ({}) -> session {}",
+                spawn.agent_nickname, spawn.agent_role, spawn.new_session_id
+            ));
+        }
+    }
+    if let Some(name) = &turn.thread_name {
+        lines.push(format!("thread_name: {name}"));
+    }
+    if let Some(trace) = &turn.trace_id {
+        lines.push(format!("trace_id: {trace}"));
+    }
+
+    ItemContent {
+        heading: format!("Turn {}", t + 1),
+        primary_title: "Details".to_string(),
+        primary: lines.join("\n"),
+        secondary: None,
+    }
+}
+
+fn tool_item_content(session: &CodexSession, t: usize, tc: usize) -> ItemContent {
+    let tool = &session.turns[t].tool_calls[tc];
+
+    let mut req = vec![
+        format!("call_id: {}", tool.call_id),
+        format!("kind: {:?}", tool.kind),
+        format!("name: {}", tool.name),
+    ];
+    if let Some(cmd) = &tool.command {
+        req.push(format!("command: {}", cmd.join(" ")));
+    }
+    if let Some(cwd) = &tool.cwd {
+        req.push(format!("cwd: {cwd}"));
+    }
+    if let Some(server) = &tool.mcp_server {
+        let tool_name = tool.mcp_tool.clone().unwrap_or_default();
+        req.push(format!("mcp: {server}/{tool_name}"));
+    }
+    if let Some(q) = &tool.web_query {
+        req.push(format!("query: {q}"));
+    }
+    if let Some(u) = &tool.web_url {
+        req.push(format!("url: {u}"));
+    }
+    if let Some(p) = &tool.image_prompt {
+        req.push(format!("prompt: {p}"));
+    }
+    if let Some(id) = &tool.subagent_id {
+        req.push(format!("subagent_id: {id}"));
+    }
+    if let Some(name) = &tool.subagent_name {
+        req.push(format!("subagent_name: {name}"));
+    }
+    if let Some(text) = &tool.input_text {
+        req.push(String::new());
+        req.push("input:".to_string());
+        req.push(text.clone());
+    } else if let Some(pretty) = pretty_json(&tool.arguments) {
+        req.push(String::new());
+        req.push("arguments:".to_string());
+        req.push(pretty);
+    }
+
+    let mut resp = vec![format!("status: {}", tool.status)];
+    if let Some(code) = tool.exit_code {
+        resp.push(format!("exit_code: {code}"));
+    }
+    if let Some(d) = tool.duration_secs {
+        resp.push(format!("duration: {d:.2}s"));
+    }
+    if let Some(success) = tool.patch_success {
+        resp.push(format!("patch_success: {success}"));
+    }
+    if let Some(path) = &tool.image_file_path {
+        resp.push(format!("file: {path}"));
+    }
+    if let Some(worker) = &tool.worker_session {
+        resp.push(format!(
+            "worker session: {} ({} turns) — press Enter from the list to open",
+            worker.id,
+            worker.turns.len()
+        ));
+    }
+    if let Some(output) = &tool.output {
+        resp.push(String::new());
+        resp.push("output:".to_string());
+        resp.push(maybe_pretty(output));
+    }
+    if let Some(changes) = &tool.patch_changes {
+        if let Some(pretty) = pretty_json(changes) {
+            resp.push(String::new());
+            resp.push("changes:".to_string());
+            resp.push(pretty);
+        }
+    }
+    if resp.len() == 1 {
+        resp.push("(no output yet)".to_string());
+    }
+
+    ItemContent {
+        heading: format!("Turn {} — {}", t + 1, tool.name),
+        primary_title: "Request".to_string(),
+        primary: req.join("\n"),
+        secondary: Some(("Response".to_string(), resp.join("\n"))),
+    }
+}
+
+fn draw_help(f: &mut Frame, screen: Screen) {
+    let area = centered_rect(72, 70, f.area());
+    f.render_widget(Clear, area);
+    let lines: Vec<&str> = match screen {
+        Screen::Picker => vec![
+            "Session Picker",
+            "",
+            "j / k / ↑ / ↓   move selection",
+            "Enter / Space   open session, or expand/collapse a date group",
+            "/               search sessions   (Esc clears, Enter keeps filter)",
+            "r               rescan the sessions directory",
+            "?               toggle this help",
+            "q / Ctrl+C      quit",
+        ],
+        Screen::Detail => vec![
+            "Session Detail",
+            "",
+            "j / k / ↑ / ↓        move selection (list) or scroll (detail)",
+            "Tab                  expand/collapse a tool call inline",
+            "e / c                expand / collapse all tool calls",
+            "Enter                open full detail, or drill into a spawned agent",
+            "h / l                switch Request / Response panel in detail view",
+            "r                    reload the session from disk",
+            "Esc / q              back to the list, or back to the picker",
+            "?                    toggle this help",
+        ],
+    };
+    let text: Vec<Line> = lines.into_iter().map(Line::from).collect();
+    let help = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).title(" Help "))
+        .wrap(Wrap { trim: false });
+    f.render_widget(help, area);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+fn turn_status_color(status: &TurnStatus) -> Color {
+    match status {
+        TurnStatus::Complete => Color::Green,
+        TurnStatus::Ongoing => Color::Cyan,
+        TurnStatus::Error | TurnStatus::Aborted => Color::Red,
+        TurnStatus::Cancelled => Color::DarkGray,
+    }
+}
+
+fn tool_status_color(status: &str) -> Color {
+    match status {
+        "success" | "completed" | "ok" => Color::Green,
+        "error" | "failed" => Color::Red,
+        "running" | "pending" => Color::Yellow,
+        _ => Color::Gray,
+    }
+}
+
+fn pretty_json(v: &serde_json::Value) -> Option<String> {
+    match v {
+        serde_json::Value::Null => None,
+        serde_json::Value::Object(m) if m.is_empty() => None,
+        _ => serde_json::to_string_pretty(v).ok(),
+    }
+}
+
+fn maybe_pretty(text: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(text)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| text.to_string())
+}
+
+fn fmt_epoch(secs: Option<u64>) -> String {
+    match secs {
+        Some(s) => chrono::DateTime::<chrono::Utc>::from_timestamp(s as i64, 0)
+            .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        None => "-".to_string(),
+    }
+}
+
+fn fmt_duration_ms(ms: Option<u64>) -> String {
+    match ms {
+        Some(ms) if ms >= 1000 => format!("{:.1}s", ms as f64 / 1000.0),
+        Some(ms) => format!("{ms}ms"),
+        None => "-".to_string(),
+    }
+}
+
+fn fmt_iso(v: &Option<String>) -> String {
+    match v {
+        Some(s) if !s.is_empty() => s
+            .replace('T', " ")
+            .trim_end_matches('Z')
+            .split('.')
+            .next()
+            .unwrap_or(s)
+            .to_string(),
+        _ => "-".to_string(),
+    }
+}
+
+fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}m", n as f64 / 1_000_000.0)
+    } else if n >= 1000 {
+        format!("{:.1}k", n as f64 / 1000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn single_line(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut t: String = s.chars().take(max.saturating_sub(1)).collect();
+        t.push('…');
+        t
+    }
+}


### PR DESCRIPTION
Adds a ratatui-based TUI, similar to claude-code-trace's, for browsing
Codex CLI sessions over SSH or without a display. Reuses the existing
parser pipeline (discover/session/turn/toolcall) — no data model
duplication.

- Session picker: date-grouped, collapsible, searchable, sorted newest first
- Session detail: turns interleave user/agent messages and tool calls in
  stream order, with inline expand/collapse (Tab, e/c) and a full-detail
  view with switchable Request/Response panels (h/l)
- Drill into spawn_agent tool calls to browse embedded worker sessions
- Ongoing sessions are re-read automatically as their rollout file grows
- ? for contextual keybinding help in both screens

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012rHzupUGuhbdLW6HPwdexf