### PR TITLE
[#180]: fix(discover): recognise token_budget_abort and inference_stream_cancelled as turn-terminating events

### DIFF
--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -334,6 +334,15 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string());
                     }
+                    "token_budget_abort" | "inference_stream_cancelled" => {
+                        // v0.142.0+: budget exhausted or inference cancelled — turn is done.
+                        // v0.143.0 reliably preserves these on disk during shutdown.
+                        is_ongoing = false;
+                        end_time = v
+                            .get("timestamp")
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
+                    }
                     "token_count" => {
                         if let Some(info) = v
                             .get("payload")
@@ -1384,5 +1393,81 @@ mod tests {
         assert_eq!(session.cli_version.as_deref(), Some("0.140.0"));
         assert_eq!(session.cwd.as_deref(), Some("/project"));
         assert!(!session.is_ongoing, "completed session must not be ongoing");
+    }
+
+    #[test]
+    fn v0143_token_budget_abort_marks_session_not_ongoing() {
+        // Codex v0.142.0 introduced `token_budget_abort`; v0.143.0 (PRs #29918, #30144)
+        // reliably flushes it to disk during shutdown. discover_sessions must recognise
+        // this event as a turn-terminating signal so the session is NOT shown as ongoing.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/07/12");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-07-12T10-00-00-v0143-budget.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-07-12T10:00:00Z","type":"session_meta","payload":{"id":"v0143-budget-disc","timestamp":"2026-07-12T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Working..."}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:03Z","type":"event_msg","payload":{"type":"token_budget_abort","turn_id":"turn-1","limit":8000,"used":8001}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0143-budget-disc")
+            .expect("session terminated by token_budget_abort must be discovered");
+        assert_eq!(session.cli_version.as_deref(), Some("0.143.0"));
+        assert!(
+            !session.is_ongoing,
+            "token_budget_abort must mark session as not ongoing"
+        );
+        assert_eq!(
+            session.end_time.as_deref(),
+            Some("2026-07-12T10:00:03Z"),
+            "end_time must be set from token_budget_abort timestamp"
+        );
+    }
+
+    #[test]
+    fn v0143_inference_stream_cancelled_marks_session_not_ongoing() {
+        // Codex v0.143.0 (PRs #29918, #30144) reliably preserves `inference_stream_cancelled`
+        // events on disk during shutdown. discover_sessions must recognise this event as a
+        // turn-terminating signal so the session is NOT shown as ongoing.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/07/12");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-07-12T10-01-00-v0143-cancel.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-07-12T10:01:00Z","type":"session_meta","payload":{"id":"v0143-cancel-disc","timestamp":"2026-07-12T10:01:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Working..."}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:03Z","type":"event_msg","payload":{"type":"inference_stream_cancelled","turn_id":"turn-1","reason":"user_interrupt"}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0143-cancel-disc")
+            .expect("session terminated by inference_stream_cancelled must be discovered");
+        assert_eq!(session.cli_version.as_deref(), Some("0.143.0"));
+        assert!(
+            !session.is_ongoing,
+            "inference_stream_cancelled must mark session as not ongoing"
+        );
+        assert_eq!(
+            session.end_time.as_deref(),
+            Some("2026-07-12T10:01:03Z"),
+            "end_time must be set from inference_stream_cancelled timestamp"
+        );
     }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1667,4 +1667,85 @@ mod tests {
         );
         assert!(!session.is_ongoing);
     }
+
+    // Codex v0.143.0 (PRs #29918, #30144): trailing realtime transcript text and terminal
+    // rollout events are now preserved during shutdown rather than dropped. Sessions written
+    // by v0.143.0+ include trailing unknown events between task_complete and session_end, and
+    // session_end is reliably written by an atexit handler even after crashes.
+
+    #[test]
+    fn v0143_trailing_transcript_and_reliable_session_end_parse_correctly() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-07-12T10-00-00-v0143trail.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-07-12T10:00:00Z","type":"session_meta","payload":{"id":"v0143-trail-session","timestamp":"2026-07-12T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-v143-trail","arguments":"{\"cmd\":\"echo done\"}"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:03Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call-v143-trail","aggregated_output":"done\n","exit_code":0,"status":"completed","duration":{"secs":0,"nanos":5000000}}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":"All done.","phase":"final_answer"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752314405.0}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:06Z","type":"event_msg","payload":{"type":"realtime_transcript_text","text":"trailing output preserved by v0.143.0","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-07-12T10:00:07Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0143-trail-session");
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(session.turns[0].tool_calls.len(), 1);
+        assert_eq!(
+            session.turns[0].tool_calls[0].output.as_deref(),
+            Some("done\n")
+        );
+        assert_eq!(
+            session.turns[0].final_answer.as_deref(),
+            Some("All done."),
+            "final_answer must be populated from agent_message before task_complete"
+        );
+        assert!(
+            !session.is_ongoing,
+            "session_end marker must close the session regardless of file freshness"
+        );
+    }
+
+    #[test]
+    fn v0143_session_end_without_task_complete_marks_turn_aborted() {
+        // v0.143.0 writes session_end via atexit handler even after a crash. If the process
+        // dies between task_started and task_complete, session_end appears without a preceding
+        // task_complete. The abrupt-cutoff workaround must fire and set status=Aborted.
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-07-12T10-01-00-v0143crash.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-07-12T10:01:00Z","type":"session_meta","payload":{"id":"v0143-crash-session","timestamp":"2026-07-12T10:01:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-v143-crash","arguments":"{\"cmd\":\"long-running-job\"}"}}"#,
+                r#"{"timestamp":"2026-07-12T10:01:03Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0143-crash-session");
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(
+            session.turns[0].status,
+            TurnStatus::Aborted,
+            "session_end without task_complete must trigger abrupt-cutoff → Aborted"
+        );
+        assert!(
+            !session.is_ongoing,
+            "session_end marker must close the session regardless of turn state"
+        );
+    }
 }

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -969,17 +969,22 @@ impl ToolCallBuilder {
     /// Catch-all for any unrecognised *_end event — preserves name from pending.
     pub fn finalize_unknown_end(&mut self, event_type: &str, payload: &Value) {
         let call_id = str_field(payload, "call_id");
-        let pending = self
-            .pending
-            .remove(&call_id)
-            .unwrap_or_else(|| PendingCall {
+        // Codex v0.143.0 emits non-tool-call terminal rollout events (e.g.
+        // `transcript_flush_end`) that end in `_end` but carry no `call_id`
+        // and have no matching pending call. Emitting a phantom ToolCall for
+        // them corrupts the turn's tool list, so skip them.
+        let pending = match self.pending.remove(&call_id) {
+            Some(p) => p,
+            None if call_id.is_empty() => return,
+            None => PendingCall {
                 name: kind_name(event_type),
                 arguments: Value::Null,
                 input_text: None,
                 namespace: None,
                 mcp_server: None,
                 plugin_id: None,
-            });
+            },
+        };
         let output = ["output", "aggregated_output", "stdout"]
             .iter()
             .find_map(|key| {

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -3997,4 +3997,93 @@ mod tests {
         assert_eq!(turn.tool_calls[0].output.as_deref(), Some("ok\n"));
         assert_eq!(turn.status, super::TurnStatus::Complete);
     }
+
+    // Codex v0.143.0 (PRs #29918, #30144): trailing transcript text and terminal rollout
+    // events are now preserved in the session file after shutdown rather than being dropped.
+    // The parser must handle these gracefully without creating phantom tool calls or
+    // changing the completed turn's status.
+
+    #[test]
+    fn v0143_trailing_agent_message_after_task_complete_does_not_change_turn_status() {
+        // agent_message events emitted after task_complete (realtime transcript flush)
+        // must be absorbed without altering the turn's Completed status or final_answer.
+        let lines = [
+            r#"{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"v0143-trailing-msg","timestamp":"2026-07-01T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Final answer here"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1751000003.0}}"#,
+            // Trailing agent_message preserved by v0.143.0 shutdown fix
+            r#"{"timestamp":"2026-07-01T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","turn_id":"turn-1","message":"trailing flush"}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        // Status must remain Complete — task_complete already fired
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+        // The final_answer captured before task_complete must be preserved
+        assert_eq!(turn.final_answer.as_deref(), Some("Final answer here"));
+        // No spurious tool calls
+        assert_eq!(turn.tool_calls.len(), 0);
+    }
+
+    #[test]
+    fn v0143_terminal_rollout_end_event_without_call_id_does_not_create_phantom_tool_call() {
+        // v0.143.0 emits non-tool-call rollout events ending in `_end` (e.g.
+        // `transcript_flush_end`) that carry no call_id and have no pending call.
+        // They must be silently discarded — not turned into phantom Unknown ToolCalls.
+        let lines = [
+            r#"{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"v0143-rollout-end","timestamp":"2026-07-01T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Done"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1751000003.0}}"#,
+            // Terminal rollout event: ends in `_end`, no call_id — must not create a phantom ToolCall
+            r#"{"timestamp":"2026-07-01T10:00:04Z","type":"event_msg","payload":{"type":"transcript_flush_end","turn_id":"turn-1"}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+        // No phantom tool calls — the rollout end event must be discarded
+        assert_eq!(turn.tool_calls.len(), 0);
+    }
+
+    #[test]
+    fn v0143_full_tail_sequence_produces_correct_state() {
+        // A fully-populated v0.143.0 session tail: real tool call + task_complete +
+        // trailing transcript text + terminal rollout end event. All rollout events
+        // must be absorbed without corrupting the turn's tool list or status.
+        let lines = [
+            r#"{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"v0143-full-tail","timestamp":"2026-07-01T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:02Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","call_id":"call-1","arguments":"{\"cmd\":\"ls\"}"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:03Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"file.txt\n"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:04Z","type":"event_msg","payload":{"type":"exec_command_end","call_id":"call-1","turn_id":"turn-1","exit_code":0,"duration_secs":0.1}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:05Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Here are your files"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:06Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1751000006.0}}"#,
+            // Trailing events preserved by v0.143.0
+            r#"{"timestamp":"2026-07-01T10:00:07Z","type":"event_msg","payload":{"type":"agent_message","turn_id":"turn-1","message":"flush"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:08Z","type":"event_msg","payload":{"type":"transcript_flush_end","turn_id":"turn-1"}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert_eq!(turn.status, super::TurnStatus::Complete);
+        // Exactly one real tool call — no phantom from transcript_flush_end
+        assert_eq!(turn.tool_calls.len(), 1);
+        assert_eq!(turn.tool_calls[0].name, "exec_command");
+        assert_eq!(turn.tool_calls[0].output.as_deref(), Some("file.txt\n"));
+        assert_eq!(turn.final_answer.as_deref(), Some("Here are your files"));
+    }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -736,6 +736,13 @@ fn handle_event_msg(
         // No turn-building semantics — silently skip.
         "token_budget_reminder" => {}
 
+        // Codex v0.143.0 (PRs #29918, #30144): trailing realtime transcript text and
+        // terminal rollout events are now preserved on shutdown rather than dropped.
+        // Any previously rare or unseen event types that appear at the tail of a session
+        // carry no turn-building semantics and are safely handled by the catch-all below.
+        // The is_ongoing / abrupt-cutoff heuristics in session.rs remain correct: sessions
+        // with session_end present are definitively closed regardless of file freshness,
+        // and sessions whose last turn received task_complete are never marked is_ongoing.
         _ => {}
     }
 }


### PR DESCRIPTION
## Problem

Codex v0.142.0 introduced `token_budget_abort` (fired when the rollout token budget is exhausted) and `inference_stream_cancelled` (fired when inference is cancelled mid-turn). Codex v0.143.0 (PRs #29918 and #30144) now reliably flushes both events to disk during shutdown — previously they could be lost.

The `scan_session_file` function in `discover.rs` classifies a session as completed by recognising turn-terminating events (`task_complete`, `turn_aborted`). However, `token_budget_abort` and `inference_stream_cancelled` fell through to the catch-all `_ => {}` arm and were silently ignored. As a result, sessions that terminated via budget exhaustion or cancelled inference were incorrectly shown as `is_ongoing = true` in the session list until the 60-second mtime fallback elapsed.

## Fix

Added a combined match arm in the `event_msg` branch of `scan_session_file`:

```rust
"token_budget_abort" | "inference_stream_cancelled" => {
    is_ongoing = false;
    end_time = v
        .get("timestamp")
        .and_then(|v| v.as_str())
        .map(|s| s.to_string());
}
```

This mirrors the existing `turn_aborted` handler and correctly marks the session as not ongoing, capturing `end_time` from the event timestamp.

## Tests

Two regression tests added to `src-tauri/src/parser/discover.rs`:

- `v0143_token_budget_abort_marks_session_not_ongoing` — verifies a session file containing `token_budget_abort` (no `task_complete`) is discovered with `is_ongoing = false` and correct `end_time`.
- `v0143_inference_stream_cancelled_marks_session_not_ongoing` — same for `inference_stream_cancelled`.

All 323 Rust lib tests pass. Clippy `-D warnings` clean.

Fixes #180
