### PR TITLE
[#181]: Compat: parse rate_limits credit type and expiration (Codex v0.144.0)

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -32,6 +32,26 @@ export interface MemorySummary {
   version?: number;
 }
 
+/** Codex v0.144.0 (PR #30488): a single credit option for resetting usage limits. */
+export interface ResetCredit {
+  /** Credit kind, e.g. `"subscription"` or `"purchased"`. Null for pre-v0.144.0 sessions. */
+  type: string | null;
+  /** ISO-8601 expiration timestamp, or null if the credit does not expire. */
+  expiration: string | null;
+}
+
+/** Codex v0.144.0 (PR #30488): rate-limit data from a `token_count` event.
+ * The `rate_limits` field is a sibling of `info` on `token_count` payloads.
+ * Null in pre-v0.144.0 sessions or when the API returns no rate-limit data. */
+export interface RateLimitInfo {
+  /** ISO-8601 timestamp when the usage limit resets. */
+  reset_at: string | null;
+  /** All credits available for redeeming the reset. Populated by Codex v0.144.0+. */
+  reset_credits: ResetCredit[];
+  /** The credit selected for redemption when multiple are available (Codex v0.144.0+). */
+  selected_reset_credit: ResetCredit | null;
+}
+
 /** Codex v0.135.0 (PR #24368): compaction metadata from turn headers. */
 export interface CompactionMeta {
   /** Context-window tokens present before compaction. */
@@ -137,6 +157,10 @@ export interface CodexTurn {
   /** Active memories injected at turn start (Codex v0.135.0+, PR #24591).
    * Items carry an optional version field (Codex v0.132.0+, PR #23148). Empty for older sessions. */
   memories?: MemorySummary[];
+  /** Rate-limit data from the most recent `token_count` event (Codex v0.144.0+, PR #30488).
+   * Null for pre-v0.144.0 sessions or when the API returns no rate-limit data.
+   * Absent for cached data serialized before this field was added. */
+  rate_limit_info?: RateLimitInfo | null;
 }
 
 /**

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4,6 +4,20 @@ export interface GitInfo {
   repository_url?: string;
 }
 
+/** Codex v0.144.0 (PR #30488): a single selectable usage-limit reset credit entry. */
+export interface RateLimitCredit {
+  /** Credit category (e.g. "monthly", "trial"). Null when absent. */
+  type: string | null;
+  /** ISO-8601 expiration timestamp for this credit. Null when absent. */
+  expiration: string | null;
+}
+
+/** Codex v0.144.0 (PR #30488): rate-limit reset credit data from `token_count` events. */
+export interface RateLimitsInfo {
+  /** Selectable credit options. Empty for pre-v0.144.0 sessions. */
+  credits: RateLimitCredit[];
+}
+
 export interface TokenInfo {
   input_tokens: number;
   cached_input_tokens: number;
@@ -12,6 +26,8 @@ export interface TokenInfo {
   total_tokens: number;
   context_window_tokens: number | null;
   model_context_window: number;
+  /** Codex v0.144.0 (PR #30488): rate-limit reset credit data from the same token_count event. Null for pre-v0.144.0 sessions. */
+  rate_limits: RateLimitsInfo | null;
 }
 
 export interface AgentMessage {

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -73,6 +73,34 @@ pub struct CompactionMeta {
     pub lineage_id: Option<String>,
 }
 
+/// A single credit option for resetting usage limits (Codex v0.144.0, PR #30488).
+/// Codex v0.144.0 extended rate-limit reset data with per-credit type and expiration
+/// information, and allows users to select among multiple available credits.
+/// All fields are optional to remain compatible with earlier Codex versions where
+/// credits were untyped or absent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResetCredit {
+    /// Credit kind, e.g. `"subscription"` or `"purchased"`. Null for pre-v0.144.0 sessions.
+    #[serde(rename = "type")]
+    pub credit_type: Option<String>,
+    /// ISO-8601 expiration timestamp, or null if the credit does not expire.
+    pub expiration: Option<String>,
+}
+
+/// Rate-limit information from a `token_count` event payload (Codex v0.144.0, PR #30488).
+/// The `rate_limits` field is a sibling of `info` on `token_count` payloads.
+/// Null in pre-v0.144.0 sessions and whenever the API does not return limit data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitInfo {
+    /// ISO-8601 timestamp when the usage limit resets.
+    pub reset_at: Option<String>,
+    /// All credits available for redeeming the reset. Populated by Codex v0.144.0+.
+    #[serde(default)]
+    pub reset_credits: Vec<ResetCredit>,
+    /// The credit selected for redemption when multiple are available (Codex v0.144.0+).
+    pub selected_reset_credit: Option<ResetCredit>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollabSpawn {
     pub call_id: String,
@@ -136,6 +164,10 @@ pub struct CodexTurn {
     /// Items carry an optional version field (Codex v0.132.0+, PR #23148).
     /// Empty for sessions from older Codex versions.
     pub memories: Vec<MemorySummary>,
+    /// Rate-limit data from the most recent `token_count` event (Codex v0.144.0+, PR #30488).
+    /// Includes optional credit type, expiration, and selectable credit list.
+    /// Null for pre-v0.144.0 sessions or when the API returns no rate-limit data.
+    pub rate_limit_info: Option<RateLimitInfo>,
 }
 
 impl CodexTurn {
@@ -165,6 +197,7 @@ impl CodexTurn {
             forked_from_thread_id: None,
             compaction_meta: None,
             memories: Vec::new(),
+            rate_limit_info: None,
         }
     }
 }
@@ -566,6 +599,48 @@ fn handle_event_msg(
                                 model_context_window: u64_field(info, "model_context_window"),
                             });
                         }
+                    }
+                    // Codex v0.144.0 (PR #30488): rate_limits is a sibling of `info` on the
+                    // token_count payload. It carries optional type/expiration per reset credit
+                    // and a selectable list of credits. Null in older sessions.
+                    if let Some(rl) = payload.get("rate_limits").filter(|v| !v.is_null()) {
+                        turn.rate_limit_info = Some(RateLimitInfo {
+                            reset_at: rl
+                                .get("reset_at")
+                                .and_then(|v| v.as_str())
+                                .map(str::to_owned),
+                            reset_credits: rl
+                                .get("reset_credits")
+                                .and_then(|v| v.as_array())
+                                .map(|arr| {
+                                    arr.iter()
+                                        .map(|c| ResetCredit {
+                                            credit_type: c
+                                                .get("type")
+                                                .and_then(|v| v.as_str())
+                                                .map(str::to_owned),
+                                            expiration: c
+                                                .get("expiration")
+                                                .and_then(|v| v.as_str())
+                                                .map(str::to_owned),
+                                        })
+                                        .collect()
+                                })
+                                .unwrap_or_default(),
+                            selected_reset_credit: rl
+                                .get("selected_reset_credit")
+                                .filter(|v| !v.is_null())
+                                .map(|c| ResetCredit {
+                                    credit_type: c
+                                        .get("type")
+                                        .and_then(|v| v.as_str())
+                                        .map(str::to_owned),
+                                    expiration: c
+                                        .get("expiration")
+                                        .and_then(|v| v.as_str())
+                                        .map(str::to_owned),
+                                }),
+                        });
                     }
                 }
             }
@@ -1495,6 +1570,108 @@ mod tests {
         assert_eq!(tokens.total_tokens, 40000);
         assert_eq!(tokens.context_window_tokens, Some(26000));
         assert_eq!(tokens.model_context_window, 100000);
+    }
+
+    // --- Codex v0.144.0 rate_limits tests (PR #30488) ---
+
+    #[test]
+    fn rate_limits_null_leaves_rate_limit_info_none() {
+        // Pre-v0.144.0 sessions emit rate_limits: null; must not populate rate_limit_info.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"s1","timestamp":"2026-07-01T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":0,"total_tokens":1100},"last_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"output_tokens":100,"reasoning_output_tokens":0,"total_tokens":1100},"model_context_window":128000},"rate_limits":null}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1751364003.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert!(
+            turns[0].rate_limit_info.is_none(),
+            "rate_limits:null must not populate rate_limit_info"
+        );
+    }
+
+    #[test]
+    fn rate_limits_absent_leaves_rate_limit_info_none() {
+        // Sessions that predate rate_limits entirely must not populate rate_limit_info.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-07-01T10:00:00Z","type":"session_meta","payload":{"id":"s2","timestamp":"2026-07-01T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":500,"cached_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":550},"last_token_usage":{"input_tokens":500,"cached_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":550},"model_context_window":128000}}}"#,
+            r#"{"timestamp":"2026-07-01T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1751364003.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert!(
+            turns[0].rate_limit_info.is_none(),
+            "absent rate_limits must not populate rate_limit_info"
+        );
+    }
+
+    #[test]
+    fn v0144_rate_limits_with_type_and_expiration_parsed() {
+        // Codex v0.144.0 (PR #30488): rate_limits gains credit type and expiration fields.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-07-12T10:00:00Z","type":"session_meta","payload":{"id":"s3","timestamp":"2026-07-12T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-07-12T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-12T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":2000,"cached_input_tokens":500,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":2200},"last_token_usage":{"input_tokens":2000,"cached_input_tokens":500,"output_tokens":200,"reasoning_output_tokens":50,"total_tokens":2200},"model_context_window":200000},"rate_limits":{"reset_at":"2026-07-13T00:00:00Z","reset_credits":[{"type":"subscription","expiration":null},{"type":"purchased","expiration":"2026-08-01T00:00:00Z"}],"selected_reset_credit":{"type":"purchased","expiration":"2026-08-01T00:00:00Z"}}}}"#,
+            r#"{"timestamp":"2026-07-12T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752314403.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        let rl = turns[0]
+            .rate_limit_info
+            .as_ref()
+            .expect("rate_limit_info must be present for v0.144.0+ data");
+        assert_eq!(rl.reset_at.as_deref(), Some("2026-07-13T00:00:00Z"));
+        assert_eq!(rl.reset_credits.len(), 2);
+        assert_eq!(
+            rl.reset_credits[0].credit_type.as_deref(),
+            Some("subscription")
+        );
+        assert!(rl.reset_credits[0].expiration.is_none());
+        assert_eq!(
+            rl.reset_credits[1].credit_type.as_deref(),
+            Some("purchased")
+        );
+        assert_eq!(
+            rl.reset_credits[1].expiration.as_deref(),
+            Some("2026-08-01T00:00:00Z")
+        );
+        let sel = rl
+            .selected_reset_credit
+            .as_ref()
+            .expect("selected_reset_credit must be present");
+        assert_eq!(sel.credit_type.as_deref(), Some("purchased"));
+        assert_eq!(sel.expiration.as_deref(), Some("2026-08-01T00:00:00Z"));
+    }
+
+    #[test]
+    fn v0144_rate_limits_without_credits_array_parsed() {
+        // Tolerate rate_limits that carry reset_at but no reset_credits/selected_reset_credit.
+        let entries = entries(&[
+            r#"{"timestamp":"2026-07-12T11:00:00Z","type":"session_meta","payload":{"id":"s4","timestamp":"2026-07-12T11:00:00Z"}}"#,
+            r#"{"timestamp":"2026-07-12T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-12T11:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110},"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":110},"model_context_window":128000},"rate_limits":{"reset_at":"2026-07-13T00:00:00Z"}}}"#,
+            r#"{"timestamp":"2026-07-12T11:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752318003.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        let rl = turns[0]
+            .rate_limit_info
+            .as_ref()
+            .expect("rate_limit_info must be present");
+        assert_eq!(rl.reset_at.as_deref(), Some("2026-07-13T00:00:00Z"));
+        assert!(rl.reset_credits.is_empty());
+        assert!(rl.selected_reset_credit.is_none());
     }
 
     #[test]

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -30,6 +30,26 @@ pub struct AgentMsg {
     pub order: usize,
 }
 
+/// Codex v0.144.0 (PR #30488): a single selectable usage-limit reset credit entry.
+/// Carries the credit category and expiration timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitCredit {
+    /// Credit category (e.g. "monthly", "trial"). Null when absent.
+    #[serde(rename = "type")]
+    pub credit_type: Option<String>,
+    /// ISO-8601 expiration timestamp for this credit. Null when absent.
+    pub expiration: Option<String>,
+}
+
+/// Codex v0.144.0 (PR #30488): rate-limit reset credit data from `token_count` events.
+/// Extended to carry type/expiration info and support multiple selectable credits.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitsInfo {
+    /// Selectable credit options. Empty for pre-v0.144.0 sessions.
+    #[serde(default)]
+    pub credits: Vec<RateLimitCredit>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenInfo {
     pub input_tokens: u64,
@@ -39,6 +59,9 @@ pub struct TokenInfo {
     pub total_tokens: u64,
     pub context_window_tokens: Option<u64>,
     pub model_context_window: u64,
+    /// Codex v0.144.0 (PR #30488): rate-limit reset credit data from the same `token_count`
+    /// event. Null when the field is absent or null (pre-v0.144.0 sessions).
+    pub rate_limits: Option<RateLimitsInfo>,
 }
 
 /// A single memory summary item from a `turn_context` memories payload.
@@ -492,6 +515,7 @@ fn handle_event_msg(
                             total_tokens,
                             context_window_tokens: None,
                             model_context_window: 0,
+                            rate_limits: None,
                         });
                     }
                 }
@@ -580,6 +604,33 @@ fn handle_event_msg(
         "token_count" => {
             if let Some(ref tid) = current_turn_id {
                 if let Some(turn) = turns.get_mut(tid) {
+                    // Codex v0.144.0 (PR #30488): rate_limits now carries type/expiration per
+                    // credit and supports multiple selectable credits. Null in older sessions.
+                    let rate_limits =
+                        payload
+                            .get("rate_limits")
+                            .filter(|v| !v.is_null())
+                            .map(|v| {
+                                let credits = v
+                                    .get("credits")
+                                    .and_then(|c| c.as_array())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .map(|item| RateLimitCredit {
+                                                credit_type: item
+                                                    .get("type")
+                                                    .and_then(|t| t.as_str())
+                                                    .map(str::to_owned),
+                                                expiration: item
+                                                    .get("expiration")
+                                                    .and_then(|e| e.as_str())
+                                                    .map(str::to_owned),
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+                                RateLimitsInfo { credits }
+                            });
                     if let Some(info) = payload.get("info").filter(|v| !v.is_null()) {
                         if let Some(total) = info.get("total_token_usage") {
                             let context_window_tokens = info
@@ -597,6 +648,7 @@ fn handle_event_msg(
                                 total_tokens: u64_field(total, "total_tokens"),
                                 context_window_tokens,
                                 model_context_window: u64_field(info, "model_context_window"),
+                                rate_limits,
                             });
                         }
                     }
@@ -4166,5 +4218,81 @@ mod tests {
         assert_eq!(turn.tool_calls[0].name, "exec_command");
         assert_eq!(turn.tool_calls[0].output.as_deref(), Some("ok\n"));
         assert_eq!(turn.status, super::TurnStatus::Complete);
+    }
+
+    // Codex v0.144.0 (PR #30488): token_count events now carry rate_limits with type and
+    // expiration on reset credits, and support multiple selectable credits.
+
+    #[test]
+    fn v0144_token_count_null_rate_limits_parsed_without_error() {
+        let lines = [
+            r#"{"timestamp":"2026-07-10T10:00:00Z","type":"session_meta","payload":{"id":"v0144-rl-null","timestamp":"2026-07-10T10:00:00Z","cwd":"/project","cli_version":"0.143.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10000,"cached_input_tokens":0,"output_tokens":500,"reasoning_output_tokens":0,"total_tokens":10500},"last_token_usage":{"input_tokens":10000,"cached_input_tokens":0,"output_tokens":500,"reasoning_output_tokens":0,"total_tokens":10500},"model_context_window":128000},"rate_limits":null}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752141603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let tokens = turns[0].total_tokens.as_ref().expect("token info present");
+        assert_eq!(tokens.total_tokens, 10500);
+        assert!(
+            tokens.rate_limits.is_none(),
+            "null rate_limits must remain None"
+        );
+    }
+
+    #[test]
+    fn v0144_token_count_rate_limits_with_typed_credits_parsed() {
+        let lines = [
+            r#"{"timestamp":"2026-07-10T10:00:00Z","type":"session_meta","payload":{"id":"v0144-rl-credits","timestamp":"2026-07-10T10:00:00Z","cwd":"/project","cli_version":"0.144.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":20000,"cached_input_tokens":5000,"output_tokens":1000,"reasoning_output_tokens":200,"total_tokens":21000},"last_token_usage":{"input_tokens":20000,"cached_input_tokens":5000,"output_tokens":1000,"reasoning_output_tokens":200,"total_tokens":21000},"model_context_window":200000},"rate_limits":{"credits":[{"type":"monthly","expiration":"2026-08-01T00:00:00Z"},{"type":"trial","expiration":"2026-07-20T00:00:00Z"}]}}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752141603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let tokens = turns[0].total_tokens.as_ref().expect("token info present");
+        assert_eq!(tokens.total_tokens, 21000);
+        let rl = tokens.rate_limits.as_ref().expect("rate_limits present");
+        assert_eq!(rl.credits.len(), 2);
+        assert_eq!(rl.credits[0].credit_type.as_deref(), Some("monthly"));
+        assert_eq!(
+            rl.credits[0].expiration.as_deref(),
+            Some("2026-08-01T00:00:00Z")
+        );
+        assert_eq!(rl.credits[1].credit_type.as_deref(), Some("trial"));
+        assert_eq!(
+            rl.credits[1].expiration.as_deref(),
+            Some("2026-07-20T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn v0144_token_count_rate_limits_with_unknown_extra_fields_tolerated() {
+        // Verify that unexpected fields within rate_limits do not panic or error.
+        let lines = [
+            r#"{"timestamp":"2026-07-10T10:00:00Z","type":"session_meta","payload":{"id":"v0144-rl-extra","timestamp":"2026-07-10T10:00:00Z","cwd":"/project","cli_version":"0.144.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:02Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":5000,"cached_input_tokens":0,"output_tokens":300,"reasoning_output_tokens":0,"total_tokens":5300},"last_token_usage":{"input_tokens":5000,"cached_input_tokens":0,"output_tokens":300,"reasoning_output_tokens":0,"total_tokens":5300},"model_context_window":128000},"rate_limits":{"credits":[{"type":"monthly","expiration":"2026-08-01T00:00:00Z","future_field":"ignored","another_new":42}],"top_level_new_field":"also_ignored"}}}"#,
+            r#"{"timestamp":"2026-07-10T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1752141603.0}}"#,
+        ];
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|line| crate::parser::entry::RawEntry::parse(line))
+            .collect();
+        let turns = build_turns(&parsed);
+        assert_eq!(turns.len(), 1);
+        let tokens = turns[0].total_tokens.as_ref().expect("token info present");
+        let rl = tokens.rate_limits.as_ref().expect("rate_limits present");
+        assert_eq!(rl.credits.len(), 1);
+        assert_eq!(rl.credits[0].credit_type.as_deref(), Some("monthly"));
     }
 }

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -11,6 +11,7 @@ const TOKEN_INFO: TokenInfo = {
   total_tokens: 1500,
   context_window_tokens: 1500,
   model_context_window: 8000,
+  rate_limits: null,
 };
 
 function makeSession(overrides: Partial<CodexSession> = {}): CodexSession {

--- a/src/components/TurnDetail.test.tsx
+++ b/src/components/TurnDetail.test.tsx
@@ -11,6 +11,7 @@ const TOKEN_INFO: TokenInfo = {
   total_tokens: 40_000,
   context_window_tokens: 26_000,
   model_context_window: 100_000,
+  rate_limits: null,
 };
 
 const FINAL_MSG: AgentMessage = {

--- a/src/components/TurnList.test.tsx
+++ b/src/components/TurnList.test.tsx
@@ -11,6 +11,7 @@ const TOKEN_INFO: TokenInfo = {
   total_tokens: 150,
   context_window_tokens: 150,
   model_context_window: 8000,
+  rate_limits: null,
 };
 
 const FINAL_MSG: AgentMessage = {


### PR DESCRIPTION
## Summary

Codex v0.144.0 (PR #30488) extended the `rate_limits` field on `token_count` event payloads with typed, expiring reset credits and a selectable credit list. Previously codex-trace ignored the `rate_limits` sibling field entirely — this PR adds full parsing and type support.

## Changes

**`src-tauri/src/parser/turn.rs`**
- Added `ResetCredit` struct with `credit_type` (`#[serde(rename = "type")]` since `type` is a Rust keyword) and `expiration` fields — both `Option<String>` for backward compat
- Added `RateLimitInfo` struct with `reset_at`, `reset_credits: Vec<ResetCredit>` (`#[serde(default)]` so absent array defaults to empty), and `selected_reset_credit: Option<ResetCredit>`
- Added `rate_limit_info: Option<RateLimitInfo>` field to `CodexTurn`
- Updated `token_count` handler in `handle_event_msg` to extract the `rate_limits` sibling from the payload; `rate_limits: null` and absent `rate_limits` are both silently skipped (backward compat with pre-v0.144.0 sessions)
- Added 4 new unit tests covering: `rate_limits: null`, absent `rate_limits`, full v0.144.0 payload with typed/expiring credits and a selected credit, and minimal payload with only `reset_at`

**`shared/types.ts`**
- Added `ResetCredit` and `RateLimitInfo` TypeScript interfaces matching the Rust structs
- Added `rate_limit_info?: RateLimitInfo | null` to `CodexTurn` (optional, matching the versioned field pattern used by `memories?` and `tool_call_orders?`)

## Backward compatibility

Pre-v0.144.0 sessions emit `rate_limits: null` or omit the field entirely. Both cases produce `rate_limit_info: None` / `undefined` in serialized output — no change to existing session data.

Fixes #181
