### PR TITLE
fix(parser): capture realtime_transcript_text mid-turn for v0.145.0 streaming audio

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -177,6 +177,10 @@ export interface CodexTurn {
    * Null for pre-v0.144.0 sessions or when the API returns no rate-limit data.
    * Absent for cached data serialized before this field was added. */
   rate_limit_info?: RateLimitInfo | null;
+  /** Audio transcript segments from realtime voice turns (Codex v0.143.0+ trailing events;
+   * Codex v0.145.0+ live mid-turn V3 streaming audio). Empty for non-voice sessions.
+   * Absent for cached data serialized before this field was added. */
+  audio_transcript?: string[];
 }
 
 /**

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1790,4 +1790,48 @@ mod tests {
             "session_end marker must close the session regardless of turn state"
         );
     }
+
+    // Codex v0.145.0: streaming realtime V3 audio conversations reintroduced (issue #201).
+    // Unlike v0.143.0's trailing-only events (after task_complete), v0.145.0 emits
+    // realtime_transcript_text mid-turn during live streaming voice conversations.
+    // The turn model must capture audio_transcript content, not silently drop it.
+
+    #[test]
+    fn v0145_live_realtime_transcript_mid_turn_is_captured() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-07-26T10-00-00-v0145audio.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-07-26T10:00:00Z","type":"session_meta","payload":{"id":"v0145-audio-session","timestamp":"2026-07-26T10:00:00Z","cwd":"/project","cli_version":"0.145.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-a1"}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:02Z","type":"event_msg","payload":{"type":"realtime_transcript_text","text":"Hello, please run the tests","turn_id":"turn-a1"}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:03Z","type":"event_msg","payload":{"type":"realtime_transcript_text","text":" for the current project","turn_id":"turn-a1"}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":"Running the tests now.","phase":"final_answer"}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-a1","completed_at":1753520405.0}}"#,
+                r#"{"timestamp":"2026-07-26T10:00:06Z","type":"session_end","payload":{}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(session.id, "v0145-audio-session");
+        assert_eq!(session.turns.len(), 1);
+        assert_eq!(
+            session.turns[0].audio_transcript,
+            vec![
+                "Hello, please run the tests".to_string(),
+                " for the current project".to_string(),
+            ],
+            "mid-turn realtime_transcript_text events must be extracted into audio_transcript"
+        );
+        assert_eq!(
+            session.turns[0].final_answer.as_deref(),
+            Some("Running the tests now."),
+        );
+        assert!(!session.is_ongoing);
+    }
 }

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -136,6 +136,11 @@ pub struct CodexTurn {
     /// Items carry an optional version field (Codex v0.132.0+, PR #23148).
     /// Empty for sessions from older Codex versions.
     pub memories: Vec<MemorySummary>,
+    /// Audio transcript segments from realtime voice turns (Codex v0.143.0+, PRs #29918, #30144;
+    /// live mid-turn segments in Codex v0.145.0+ V3 streaming realtime audio).
+    /// Empty for non-voice sessions.
+    #[serde(default)]
+    pub audio_transcript: Vec<String>,
 }
 
 impl CodexTurn {
@@ -165,6 +170,7 @@ impl CodexTurn {
             forked_from_thread_id: None,
             compaction_meta: None,
             memories: Vec::new(),
+            audio_transcript: Vec::new(),
         }
     }
 }
@@ -743,6 +749,31 @@ fn handle_event_msg(
         // semantics and are explicitly skipped so ordinary sessions with auth flows parse
         // without corrupting turn data.
         "mcp_auth_request" | "mcp_auth_result" | "mcp_auth_challenge" | "mcp_auth_complete" => {}
+
+        // Codex v0.143.0 (PRs #29918, #30144): trailing realtime transcript text preserved
+        // during shutdown. Codex v0.145.0 reintroduces streaming realtime V3 audio and emits
+        // this event type mid-turn (live voice segments, not just shutdown-time trailing text).
+        // Extract the transcript so voice-turn content is surfaced rather than silently dropped.
+        "realtime_transcript_text" => {
+            let text = payload
+                .get("text")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if !text.is_empty() {
+                let target_id = payload
+                    .get("turn_id")
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string())
+                    .or_else(|| current_turn_id.clone());
+                if let Some(ref tid) = target_id {
+                    if let Some(turn) = turns.get_mut(tid) {
+                        turn.audio_transcript.push(text);
+                    }
+                }
+            }
+        }
 
         _ => {}
     }


### PR DESCRIPTION
Fixes #201

## Problem

Codex v0.145.0 reintroduces streaming realtime V3 audio conversations (live voice input/output during a turn), building on the voice subsystem removed in v0.140.0 (PR #27801) and partially reinstated as trailing-only `realtime_transcript_text` events in v0.143.0 (PRs #29918, #30144).

codex-trace's parser previously tolerated `realtime_transcript_text` as a no-op — it was accepted without error but never extracted into the turn model. If v0.145.0 emits this event type mid-turn (live audio segments, not just a shutdown-time trailing transcript), the parser would silently drop the audio-turn content instead of crashing, showing an incomplete or empty turn for voice-based conversations.

## Fix

- Added a new `audio_transcript: Vec<String>` field to `CodexTurn` (turn.rs), mirrored in `shared/types.ts`.
- Extended the existing `realtime_transcript_text` handler in `handle_event_msg` to extract the transcript text and push it onto the target turn's `audio_transcript`, resolved via the payload's `turn_id` with a fallback to the current turn. This works whether the event arrives mid-turn (v0.145.0 live streaming) or trailing (v0.143.0 shutdown-time behavior), since extraction no longer depends on timing.
- Added a regression test, `v0145_live_realtime_transcript_mid_turn_is_captured`, with a session fixture where `realtime_transcript_text` events occur mid-turn (interleaved with other event_msg entries, before `task_complete`) and asserts the segments are captured in order without disrupting tool calls or `final_answer`.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml`: 340 unit tests + 3 ACL integration tests pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`: clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`: clean
- `npx vitest run`: 143 tests pass
- `npx tsc --noEmit`, `npx oxlint`, `npx oxfmt --check`: clean (pre-existing unrelated oxlint warning in MarkdownRenderer.tsx, not touched by this change)

## Notes

The pre-v0.140.0 legacy response_item type string `"audio_transcript"` (already skipped as a no-op for old archived sessions, turn.rs) is unrelated to the new struct field of the same name — different namespace, only exercised by sessions with `cli_version: "0.139.0"` in the existing archive-compat test. No frontend UI changes included; the issue scopes this fix to the turn model, matching how the sibling `realtime_transcript_text` handling was originally described.
