### PR TITLE
Fix #209: discover rollout files Codex compresses to .jsonl.zst

### DIFF
--- a/src-tauri/src/parser/compression.rs
+++ b/src-tauri/src/parser/compression.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // zstd frame magic: 0xFD2FB528 stored little-endian => bytes [0x28, 0xB5, 0x2F, 0xFD]
 const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
@@ -41,6 +41,27 @@ fn read_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> std::io::Result<usize>
         }
     }
     Ok(total)
+}
+
+/// Resolve the actual on-disk path for a rollout session file.
+///
+/// Codex's background compression worker can replace a cold plain `rollout-*.jsonl`
+/// file with a `rollout-*.jsonl.zst` sibling and remove the original (see
+/// `codex-rs/rollout/src/compression.rs` upstream). A watcher holding the original
+/// plain path would otherwise find it gone and silently stop updating. Returns
+/// `None` if neither representation exists.
+pub fn resolve_rollout_path(path: &Path) -> Option<PathBuf> {
+    if path.exists() {
+        return Some(path.to_path_buf());
+    }
+    let name = path.file_name()?.to_str()?;
+    if !name.ends_with(".jsonl.zst") {
+        let compressed = path.with_file_name(format!("{name}.zst"));
+        if compressed.exists() {
+            return Some(compressed);
+        }
+    }
+    None
 }
 
 /// Read a session file that may be plain text or zstd-compressed.
@@ -170,5 +191,31 @@ mod tests {
         let tmp = tempdir().unwrap();
         let path = tmp.path().join("does-not-exist.jsonl");
         assert!(open_session_reader(&path).is_err());
+    }
+
+    #[test]
+    fn resolve_rollout_path_returns_plain_path_when_it_exists() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-plain.jsonl");
+        std::fs::write(&path, "content").unwrap();
+        assert_eq!(resolve_rollout_path(&path), Some(path));
+    }
+
+    #[test]
+    fn resolve_rollout_path_falls_back_to_compressed_sibling() {
+        // Issue #209: a watched session that goes cold can be replaced by Codex's
+        // compression worker with a `.jsonl.zst` sibling, removing the plain file.
+        let tmp = tempdir().unwrap();
+        let plain_path = tmp.path().join("rollout-cold.jsonl");
+        let compressed_path = tmp.path().join("rollout-cold.jsonl.zst");
+        std::fs::write(&compressed_path, compress_zstd(b"content")).unwrap();
+        assert_eq!(resolve_rollout_path(&plain_path), Some(compressed_path));
+    }
+
+    #[test]
+    fn resolve_rollout_path_returns_none_when_neither_representation_exists() {
+        let tmp = tempdir().unwrap();
+        let path = tmp.path().join("rollout-gone.jsonl");
+        assert_eq!(resolve_rollout_path(&path), None);
     }
 }

--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -96,13 +96,36 @@ fn collect_jsonl_files(dir: &Path, infos: &mut Vec<CodexSessionInfo>) -> Result<
         let path = entry.path();
         if path.is_dir() {
             collect_jsonl_files(&path, infos)?;
-        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if name.starts_with("rollout-") {
-                if let Some(info) = scan_session_file(&path) {
-                    infos.push(info);
-                }
+            continue;
+        }
+
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if !name.starts_with("rollout-") {
+            continue;
+        }
+
+        // Codex's background rollout compression worker (codex-rs/rollout/src/compression.rs,
+        // present since v0.137.0 and still active as of v0.146.0's #34566) replaces a cold
+        // `rollout-*.jsonl` file with a `rollout-*.jsonl.zst` sibling and removes the plain
+        // file. Without recognizing the compressed suffix, discovery silently drops any
+        // session Codex has compressed — it just vanishes from the list with no indication.
+        if let Some(plain_name) = name
+            .strip_suffix(".jsonl.zst")
+            .map(|s| format!("{s}.jsonl"))
+        {
+            // A plain sibling briefly coexists with its compressed copy while Codex
+            // materializes it back for append; skip the compressed copy in that case so
+            // the session isn't counted twice.
+            let plain_sibling = path.with_file_name(plain_name);
+            if plain_sibling.exists() {
+                continue;
             }
+        } else if !name.ends_with(".jsonl") {
+            continue;
+        }
+
+        if let Some(info) = scan_session_file(&path) {
+            infos.push(info);
         }
     }
 
@@ -1289,6 +1312,72 @@ mod tests {
         assert!(
             sessions.iter().any(|s| s.id == "v0137-compressed"),
             "compressed session must be found"
+        );
+    }
+
+    // Issue #209 / Codex v0.146.0 (PR #34566 touches rollout compression cleanup):
+    // Codex's background compression worker (codex-rs/rollout/src/compression.rs) replaces a
+    // cold `rollout-*.jsonl` file with a `rollout-*.jsonl.zst` sibling and removes the plain
+    // file — it does not rewrite zstd bytes into the original `.jsonl` name. discover_sessions
+    // must recognize the `.jsonl.zst` suffix so a compressed session isn't silently dropped.
+
+    #[test]
+    fn discover_sessions_v0146_compressed_only_session_uses_real_zst_suffix() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/07/28");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        // Real Codex compression appends `.zst` to the plain filename rather than
+        // compressing in place under the original `.jsonl` name.
+        let compressed_path = day_dir.join("rollout-2026-07-28T10-00-00-coldsession.jsonl.zst");
+        let content = [
+            r#"{"timestamp":"2026-07-28T10:00:00Z","type":"session_meta","payload":{"id":"v0146-cold","timestamp":"2026-07-28T10:00:00Z","cli_version":"0.146.0"}}"#,
+            r#"{"timestamp":"2026-07-28T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-07-28T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","completed_at":1753696802.0}}"#,
+        ]
+        .join("\n");
+        std::fs::write(&compressed_path, compress_zstd(content.as_bytes())).unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        assert!(
+            sessions.iter().any(|s| s.id == "v0146-cold"),
+            "session compressed to a `.jsonl.zst` sibling must still be discovered, not silently dropped"
+        );
+    }
+
+    #[test]
+    fn discover_sessions_v0146_compressed_sibling_of_existing_plain_not_double_counted() {
+        // Codex briefly materializes a compressed rollout back to plain `.jsonl` for append
+        // before removing the `.zst` copy. If both are momentarily present, the session must
+        // be counted once, not twice.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/07/28");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let base_name = "rollout-2026-07-28T11-00-00-transition.jsonl";
+        let content = [
+            r#"{"timestamp":"2026-07-28T11:00:00Z","type":"session_meta","payload":{"id":"v0146-transition","timestamp":"2026-07-28T11:00:00Z","cli_version":"0.146.0"}}"#,
+            r#"{"timestamp":"2026-07-28T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-07-28T11:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","completed_at":1753700402.0}}"#,
+        ]
+        .join("\n");
+
+        std::fs::write(day_dir.join(base_name), &content).unwrap();
+        std::fs::write(
+            day_dir.join(format!("{base_name}.zst")),
+            compress_zstd(content.as_bytes()),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let matches: Vec<_> = sessions
+            .iter()
+            .filter(|s| s.id == "v0146-transition")
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "plain + compressed copies of the same rollout must be counted once, not twice"
         );
     }
 

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -61,12 +61,22 @@ struct SessionUpdatePayload {
     session: crate::parser::session::CodexSession,
 }
 
+/// True for `rollout-*.jsonl` and `rollout-*.jsonl.zst` files — Codex's background
+/// compression worker replaces a cold plain rollout with a `.jsonl.zst` sibling, so both
+/// representations must be treated as session files for change detection.
+fn is_rollout_jsonl_name(name: &str) -> bool {
+    name.ends_with(".jsonl") || name.ends_with(".jsonl.zst")
+}
+
 fn is_related_session_path(changed_path: &Path, session_file: &Path) -> bool {
     if changed_path == session_file {
         return true;
     }
 
-    changed_path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+    changed_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(is_rollout_jsonl_name)
         && changed_path.parent() == session_file.parent()
 }
 
@@ -119,7 +129,10 @@ pub fn start_session_watcher(
                 _ = stop_rx.recv() => break,
                 Some(()) = signal_rx.recv() => {
                     let p = std::path::Path::new(&path_for_rebuild);
-                    let session = match parse_session(p) {
+                    let Some(resolved) = crate::parser::compression::resolve_rollout_path(p) else {
+                        continue;
+                    };
+                    let session = match parse_session(&resolved) {
                         Ok(s) => s,
                         Err(_) => continue,
                     };
@@ -183,7 +196,7 @@ pub fn start_picker_watcher(
             |event| {
                 event.paths.iter().any(|p| {
                     let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                    name.ends_with(".jsonl")
+                    is_rollout_jsonl_name(name)
                 })
             },
             signal_tx_clone,
@@ -243,6 +256,16 @@ mod tests {
         let session_file = Path::new("/tmp/sessions/rollout-parent.jsonl");
         let worker_file = Path::new("/tmp/sessions/rollout-worker.jsonl");
         assert!(is_related_session_path(worker_file, session_file));
+    }
+
+    #[test]
+    fn related_session_path_matches_compressed_zst_sibling() {
+        // Issue #209: Codex's background compression worker replaces a cold rollout
+        // with a `.jsonl.zst` sibling. The watcher must still treat that as related
+        // so the picker/session view refreshes instead of going stale.
+        let session_file = Path::new("/tmp/sessions/rollout-parent.jsonl");
+        let compressed_sibling = Path::new("/tmp/sessions/rollout-parent.jsonl.zst");
+        assert!(is_related_session_path(compressed_sibling, session_file));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #209. Codex's background rollout compression worker (`codex-rs/rollout/src/compression.rs`, active since v0.137.0 and still touched by v0.146.0's #34566 "Protect fork history references during rollout cleanup") compresses any `rollout-*.jsonl` file idle for 7+ days into a `rollout-*.jsonl.zst` sibling and deletes the plain file.

codex-trace's directory scan only matched files with a bare `.jsonl` extension, so once Codex compresses a session, its file is silently skipped entirely during discovery — the session vanishes from the picker with zero indication, which is worse than the "truncated history" scenario the issue speculated about.

The three specific PRs cited in the issue (#34562, #34566, #34533) turned out, on inspection of the actual upstream source, to be internal SQLite/fork-reference refactors that don't mutate rollout JSONL content in place. But tracing the code path they touch led to the real, confirmed bug in the existing (and pre-existing, not v0.146.0-introduced) compression mechanism described above.

## Changes

- `src-tauri/src/parser/discover.rs`: recognize `rollout-*.jsonl.zst` files during directory scan, deduping the brief window where Codex materializes a plain copy alongside the compressed one for append (real Codex source keeps both briefly during a resume-for-append transition).
- `src-tauri/src/watcher.rs`: react to `.jsonl.zst` changes in both the per-session and picker file watchers; resolve a plain path to its compressed sibling when rebuilding a watched session that goes cold mid-view.
- `src-tauri/src/parser/compression.rs`: add `resolve_rollout_path()` to find whichever representation (plain or compressed) exists on disk.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml`: 354 passed (5 new tests covering compressed-only discovery, plain+compressed dedup, watcher recognition of `.jsonl.zst`, and `resolve_rollout_path`)
- `npm test` (vitest + cargo test): 146 vitest + 354 cargo test passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`: clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`: clean
- `npx tsc --noEmit`: clean

## Remaining concerns

Could not validate against a real v0.146.0 session capture with an actual `.jsonl.zst` file — local Codex CLI here is v0.142.5 and no local session has hit the 7-day compression threshold. Validation is based on reading the real upstream Rust source (`codex-rs/rollout/src/compression.rs` at tag `rust-v0.146.0`) rather than an observed file on disk.
