### PR TITLE
[#210]: Parse Codex v0.146.0 paginated thread history_base

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -227,6 +227,12 @@ export interface CodexSession {
    * Known values: "suggest", "auto-edit", "full-auto", "writes" (new in v0.144.0).
    * Null for sessions predating v0.144.0 or when the field is absent. */
   approval_mode: string | null;
+  /** Codex v0.146.0 (PRs #34621, #35220): thread ID this rollout's paginated history
+   * inherits from (session_meta.payload.history_base.thread_id). Distinct from the
+   * per-turn `forked_from_thread_id` and compaction `lineage_id` fields — this one marks
+   * the whole rollout file as a continuation of another paginated thread's history.
+   * Null for legacy-history sessions or paginated threads with no inherited prefix. */
+  history_base_thread_id: string | null;
 }
 
 export interface CodexSessionInfo {
@@ -260,6 +266,12 @@ export interface CodexSessionInfo {
    * Known values: "suggest", "auto-edit", "full-auto", "writes" (new in v0.144.0).
    * Null for sessions predating v0.144.0 or when the field is absent. */
   approval_mode: string | null;
+  /** Codex v0.146.0 (PRs #34621, #35220): thread ID this rollout's paginated history
+   * inherits from (session_meta.payload.history_base.thread_id). Distinct from the
+   * per-turn `forked_from_thread_id` and compaction `lineage_id` fields — this one marks
+   * the whole rollout file as a continuation of another paginated thread's history.
+   * Null for legacy-history sessions or paginated threads with no inherited prefix. */
+  history_base_thread_id: string | null;
 }
 
 export interface SettingsResponse {

--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -46,10 +46,21 @@ pub struct CodexSessionInfo {
     /// Known values: "suggest", "auto-edit", "full-auto", "writes" (new in v0.144.0).
     /// Null for sessions predating v0.144.0 or when the field is absent.
     pub approval_mode: Option<String>,
+    /// Codex v0.146.0 (PRs #34621, #35220): thread ID this rollout's paginated history
+    /// inherits from, read from session_meta.payload.history_base.thread_id. Distinct from
+    /// the per-turn `forked_from_thread_id` and compaction `lineage_id` fields — this one
+    /// marks a whole rollout file as a continuation of another paginated thread's history.
+    /// Null for legacy-history sessions or paginated threads with no inherited prefix.
+    pub history_base_thread_id: Option<String>,
 }
 
 /// Scan a sessions directory recursively for all rollout-*.jsonl files.
 /// Returns CodexSessionInfo sorted by filename descending (newest first).
+///
+/// Note on Codex v0.146.0 ephemeral/temporary forks (issue #210): the app-server keeps
+/// ephemeral forked threads "pathless" and never materializes them to a rollout file, so
+/// they cannot appear here and need no explicit filtering — this scanner only ever sees
+/// files that were actually written to `sessions_dir`.
 pub fn discover_sessions(sessions_dir: &Path) -> Result<Vec<CodexSessionInfo>, String> {
     if !sessions_dir.exists() {
         return Ok(Vec::new());
@@ -161,6 +172,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         ai_title,
         meta_archived,
         approval_mode,
+        history_base_thread_id,
     ) = match entry.entry_type.as_str() {
         "session_meta" => {
             let id = extract_session_id(payload);
@@ -209,6 +221,16 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
+            // Codex v0.146.0 (PRs #34621, #35220): a paginated rollout continuing another
+            // thread's history carries session_meta.history_base.thread_id pointing at the
+            // source rollout. This is the lineage-chain marker for session-tree reconstruction
+            // across paginated forks — separate from the per-turn forked_from_thread_id.
+            let history_base_thread_id = payload
+                .get("history_base")
+                .and_then(|b| b.get("thread_id"))
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
             (
                 id,
                 start_time,
@@ -224,6 +246,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 ai_title,
                 meta_archived,
                 approval_mode,
+                history_base_thread_id,
             )
         }
         "session_meta_root" => {
@@ -236,7 +259,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .map(|s| s.to_string());
             (
                 id, start_time, None, None, None, git_branch, None, false, false, None, None, None,
-                false, None,
+                false, None, None,
             )
         }
         _ => return None,
@@ -481,6 +504,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         date_group,
         ai_title,
         approval_mode,
+        history_base_thread_id,
     })
 }
 
@@ -1482,5 +1506,91 @@ mod tests {
             Some("2026-07-12T10:01:03Z"),
             "end_time must be set from inference_stream_cancelled timestamp"
         );
+    }
+
+    // Codex v0.146.0 (PRs #34621, #35220, issue #210): paginated threads that fork or
+    // inherit history from another rollout carry session_meta.history_base.thread_id,
+    // pointing at the source rollout this one continues from. discover_sessions must
+    // surface this so a paginated-history continuation is not treated as a fully
+    // independent session with no prior context.
+
+    #[test]
+    fn discover_sessions_v0146_reads_history_base_thread_id() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/01");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-01T10-00-00-v0146-fork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","payload":{"id":"v0146-fork-child","timestamp":"2026-08-01T10:00:00Z","cwd":"/project","cli_version":"0.146.0","model_provider":"openai","history_mode":"paginated","history_base":{"thread_id":"v0146-fork-parent","end_ordinal_exclusive":5,"end_byte_offset":512}}}"#,
+                r#"{"timestamp":"2026-08-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-01T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1785657602.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0146-fork-child")
+            .expect("paginated fork continuation must be discovered");
+        assert_eq!(
+            session.history_base_thread_id.as_deref(),
+            Some("v0146-fork-parent"),
+            "history_base.thread_id must be surfaced as history_base_thread_id"
+        );
+    }
+
+    #[test]
+    fn discover_sessions_v0146_no_history_base_is_none() {
+        // Legacy-history sessions (and paginated sessions with no inherited prefix) must
+        // not set history_base_thread_id.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/01");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-01T10-01-00-v0146-nofork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-01T10:01:00Z","type":"session_meta","payload":{"id":"v0146-nofork","timestamp":"2026-08-01T10:01:00Z","cwd":"/project","cli_version":"0.146.0","model_provider":"openai","history_mode":"legacy"}}"#,
+                r#"{"timestamp":"2026-08-01T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-01T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1785657662.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0146-nofork")
+            .expect("session must be discovered");
+        assert!(
+            session.history_base_thread_id.is_none(),
+            "session without history_base must have history_base_thread_id == None"
+        );
+    }
+
+    #[test]
+    fn discover_sessions_v0146_malformed_history_base_does_not_panic() {
+        // Defensive: a history_base object missing thread_id must be tolerated, not panic.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/01");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-01T10-02-00-v0146-malformed.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"timestamp":"2026-08-01T10:02:00Z","type":"session_meta","payload":{"id":"v0146-malformed","timestamp":"2026-08-01T10:02:00Z","history_mode":"paginated","history_base":{"end_ordinal_exclusive":5}}}"#,
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0146-malformed")
+            .expect("session must be discovered even with malformed history_base");
+        assert!(session.history_base_thread_id.is_none());
     }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -42,6 +42,12 @@ pub struct CodexSession {
     /// function_call_output for spawn_agent to be empty. When this is true, multi-agent
     /// subagent lineage is absent and users should set hide_spawn_agent_metadata = false.
     pub has_missing_spawn_metadata: bool,
+    /// Codex v0.146.0 (PRs #34621, #35220): thread ID this rollout's paginated history
+    /// inherits from, read from session_meta.payload.history_base.thread_id. Distinct from
+    /// the per-turn `forked_from_thread_id` and compaction `lineage_id` fields — this one
+    /// marks the whole rollout file as a continuation of another paginated thread's history.
+    /// Null for legacy-history sessions or paginated threads with no inherited prefix.
+    pub history_base_thread_id: Option<String>,
 }
 
 /// Parse a Codex JSONL session file into a CodexSession.
@@ -87,6 +93,7 @@ fn parse_session_inner(
         ai_title: None,
         is_headless: false,
         has_missing_spawn_metadata: false,
+        history_base_thread_id: None,
     };
 
     // Parse session_meta from first matching entry
@@ -303,6 +310,15 @@ fn parse_session_meta_new(session: &mut CodexSession, payload: &Value, _raw: &Va
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .or_else(|| opt_str(payload, "instructions"));
+
+    // Codex v0.146.0 (PRs #34621, #35220): a paginated rollout continuing another thread's
+    // history carries session_meta.history_base.thread_id pointing at the source rollout.
+    session.history_base_thread_id = payload
+        .get("history_base")
+        .and_then(|b| b.get("thread_id"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
 }
 
 fn parse_session_meta_root(session: &mut CodexSession, raw: &Value) {
@@ -1833,5 +1849,55 @@ mod tests {
             Some("Running the tests now."),
         );
         assert!(!session.is_ongoing);
+    }
+
+    // Codex v0.146.0 (PRs #34621, #35220, issue #210): a paginated thread that forks or
+    // inherits history from another rollout carries session_meta.history_base.thread_id,
+    // pointing at the source rollout it continues from. This is distinct from the per-turn
+    // forked_from_thread_id and compaction lineage_id fields.
+
+    #[test]
+    fn v0146_parse_session_reads_history_base_thread_id() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-08-01T10-00-00-v0146fork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","payload":{"id":"v0146-fork-child","timestamp":"2026-08-01T10:00:00Z","cwd":"/project","cli_version":"0.146.0","model_provider":"openai","history_mode":"paginated","history_base":{"thread_id":"v0146-fork-parent","end_ordinal_exclusive":5,"end_byte_offset":512}}}"#,
+                r#"{"timestamp":"2026-08-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-01T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1785657602.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(
+            session.history_base_thread_id.as_deref(),
+            Some("v0146-fork-parent")
+        );
+    }
+
+    #[test]
+    fn v0146_parse_session_no_history_base_is_none() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-08-01T10-01-00-v0146nofork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-01T10:01:00Z","type":"session_meta","payload":{"id":"v0146-nofork","timestamp":"2026-08-01T10:01:00Z","cwd":"/project","cli_version":"0.146.0","model_provider":"openai","history_mode":"legacy"}}"#,
+                r#"{"timestamp":"2026-08-01T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-01T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1785657662.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert!(session.history_base_thread_id.is_none());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -179,6 +179,7 @@ mod tests {
                     date_group: String::new(),
                     ai_title: None,
                     approval_mode: None,
+                    history_base_thread_id: None,
                 }],
             });
         }
@@ -225,6 +226,7 @@ mod tests {
                     date_group: String::new(),
                     ai_title: None,
                     approval_mode: None,
+                    history_base_thread_id: None,
                 }],
             });
         }

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -35,6 +35,7 @@ function makeSession(overrides: Partial<CodexSession> = {}): CodexSession {
     has_missing_spawn_metadata: false,
     is_archived: false,
     approval_mode: null,
+    history_base_thread_id: null,
     ...overrides,
   };
 }

--- a/src/components/SidebarTree.test.tsx
+++ b/src/components/SidebarTree.test.tsx
@@ -23,6 +23,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     is_headless: false,
     is_archived: false,
     approval_mode: null,
+    history_base_thread_id: null,
     worker_nickname: null,
     worker_role: null,
     spawned_worker_ids: [],

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -84,6 +84,7 @@ function makeWorkerSession(toolCalls: CodexToolCall[]): CodexSession {
     has_missing_spawn_metadata: false,
     is_archived: false,
     approval_mode: null,
+    history_base_thread_id: null,
   };
 }
 

--- a/src/components/WorkerPanel.test.tsx
+++ b/src/components/WorkerPanel.test.tsx
@@ -87,6 +87,7 @@ function makeSession(toolCalls: CodexToolCall[]): CodexSession {
     has_missing_spawn_metadata: false,
     is_archived: false,
     approval_mode: null,
+    history_base_thread_id: null,
   };
 }
 

--- a/src/lib/sessionDisplay.test.ts
+++ b/src/lib/sessionDisplay.test.ts
@@ -22,6 +22,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     is_headless: false,
     is_archived: false,
     approval_mode: null,
+    history_base_thread_id: null,
     worker_nickname: null,
     worker_role: null,
     spawned_worker_ids: [],


### PR DESCRIPTION
## Summary

Codex v0.146.0 adds paginated thread history support, including forks that inherit history from another rollout. This PR verifies both concerns raised in #210 directly against the `rust-v0.146.0` source in `openai/codex`, and fixes the one that's real.

## What changed

- **Paginated thread lineage (`history_base`) — real gap, fixed.** v0.146.0 writes a new `session_meta.payload.history_base` field (`{thread_id, end_ordinal_exclusive, end_byte_offset}`) marking a rollout file as a continuation of another paginated thread's history. This is distinct from the existing per-turn `forked_from_thread_id` and compaction `lineage_id` fields — codex-trace had no handling for it, so a paginated-fork continuation would show up as a disconnected session with no visible lineage. Parsed `history_base.thread_id` into a new `history_base_thread_id` field on both `CodexSessionInfo` (`discover.rs`, picker/discovery) and `CodexSession` (`session.rs`, full parse), mirroring the existing `lineage_id`/`compaction_meta` exposure pattern. Mirrored in `shared/types.ts`.
- **Ephemeral/temporary forks leaking into discovery — verified not applicable.** Confirmed from the actual v0.146.0 source (`thread_fork_ephemeral_remains_pathless_and_omits_listing` tests, doc comment "should not be materialized on disk") that ephemeral forks are never written to disk — they stay "pathless." Since `discover_sessions` only scans files that exist on disk, there's nothing to filter. Documented this as an audit finding via a code comment rather than adding speculative filtering logic for a scenario that can't occur.

## Scope note

Cross-file turn merging (rendering a paginated fork's inherited history inline in the turn list) is intentionally **not** implemented. Precise truncation would need ordinal-level tracking codex-trace's parser doesn't have infrastructure for, and there's no real v0.146.0-generated rollout file available yet to verify a merge implementation against. This follows the same scope as the existing `lineage_id` field: captured and exposed, not yet wired into cross-file UI logic.

## Testing

- 5 new Rust unit tests (present / absent / malformed `history_base` cases) across `discover.rs` and `session.rs`.
- `npm test` (146 vitest + 353 cargo test): all pass.
- `cargo clippy -- -D warnings`: clean.
- `tsc --noEmit`, `oxlint`, `oxfmt --check`, `cargo fmt --check`: clean.

Closes #210
