### PR TITLE
test(compat): audit v0.147.0 --full-auto flag removal

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1626,4 +1626,38 @@ mod tests {
         assert_eq!(event_msg_type(&complete.payload), Some("mcp_auth_complete"));
         assert_eq!(complete.payload["success"], true);
     }
+
+    // Codex v0.147.0 (PR #36054): the deprecated `codex exec --full-auto` CLI flag
+    // has been removed entirely; `--sandbox workspace-write` is now the only way to
+    // get that behavior. codex-trace never invokes the Codex CLI and never passes
+    // this flag to any process — it only reads `permission_profile` as recorded
+    // session metadata, which is unrelated to the removed CLI flag and keeps its
+    // existing string values (including the historical "full-auto" value). Verify
+    // all four standard entry types from a v0.147.0 session still parse correctly
+    // and that a "full-auto" permission profile value is read as data, unaffected
+    // by the flag's removal.
+    #[test]
+    fn v0147_full_auto_flag_removal_does_not_affect_session_meta_parsing() {
+        let lines = [
+            r#"{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","payload":{"id":"v0147-session","timestamp":"2026-08-01T10:00:00Z","cwd":"/project","cli_version":"0.147.0","model_provider":"openai","permission_profile":"full-auto"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:02Z","type":"response_item","payload":{"type":"message","role":"assistant","content":"Hello"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:03Z","type":"turn_context","payload":{"model":"gpt-5","cwd":"/project"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1785578404.0}}"#,
+        ];
+        let expected_types = [
+            "session_meta",
+            "event_msg",
+            "response_item",
+            "turn_context",
+            "event_msg",
+        ];
+        for (line, expected) in lines.iter().zip(expected_types.iter()) {
+            let entry = RawEntry::parse(line).expect("parse failed");
+            assert_eq!(entry.entry_type, *expected, "wrong type for: {line}");
+        }
+        let meta = RawEntry::parse(lines[0]).unwrap();
+        assert_eq!(meta.payload["cli_version"], "0.147.0");
+        assert_eq!(meta.payload["permission_profile"], "full-auto");
+    }
 }


### PR DESCRIPTION
## What

Codex v0.147.0 removed the deprecated `codex exec --full-auto` CLI flag entirely (`--sandbox workspace-write` is now the only way to get that behavior). This adds a regression test auditing that codex-trace is unaffected.

## Why

codex-trace is a read-only JSONL viewer — it never invokes the Codex CLI or passes `--full-auto` to any process. The string only appears as a documented value of the `permission_profile` field recorded inside `session_meta` payloads, which is unrelated to the removed CLI flag.

The real risk called out in the issue is external: anyone piping `codex exec --full-auto ...` into a script will now hit a hard CLI argument-parsing error instead of a deprecation warning, so no rollout file gets written at all. That's an upstream Codex CLI behavior change with no code-level fix available in codex-trace — there's nothing to parse if the session file is never created.

## Change

- `src-tauri/src/parser/entry.rs`: added `v0147_full_auto_flag_removal_does_not_affect_session_meta_parsing`, verifying all four standard entry types (`session_meta`, `event_msg`, `response_item`, `turn_context`) still parse correctly for a v0.147.0 session, including a `permission_profile` of `"full-auto"` read as data.

This follows the repo's established pattern for "no functional impact" Codex compat audits (see prior tests like `v0144_all_standard_entry_types_parse_correctly`, `v0142_all_standard_entry_types_parse_correctly`) — a version-scoped regression test rather than a docs/README addition, since earlier README/AGENTS.md compat-audit sections were deliberately removed from this repo during a prior cleanup.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` — 361 + 3 tests pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — clean
- `npm test` (vitest + cargo test) — pass
- `npx tsc --noEmit`, `npx oxfmt --check` — clean
- `npx oxlint` — clean (one pre-existing unrelated warning in `MarkdownRenderer.tsx`, not touched by this change)

Fixes #218
