### PR TITLE
docs(parser): audit Codex v0.147.0 MCP SDK 3.0.0 and 2026-07-28 protocol (#222)

### DIFF
--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -960,6 +960,17 @@ fn handle_response_item(
         // tool_search_call mid-turn; matching tools are returned in tool_search_call_output.
         // Merge the discovered tools into the current turn's dynamic tool registry so
         // subsequent function_call entries are classified as McpTool correctly.
+        //
+        // Codex v0.147.0 (issue #222): the bundled MCP SDK bump to 3.0.0 (#36001) and the
+        // opt-in MCP 2026-07-28 protocol (#35724, #35725, #35590, #35742) were audited against
+        // the openai/codex source. Both only change the wire protocol between Codex and MCP
+        // *servers* (SDK type renames, paginated `server/discover` requests, multi-round
+        // tools/call negotiation, non-blocking server startup) — that pagination is resolved
+        // internally before Codex ever builds `dynamic_tools` or tool-search results. Neither
+        // change touches `codex-rs/protocol` (rollout item types), `app-server/src/dynamic_tools.rs`,
+        // or the tool_search_call/tool_search_call_output mechanism handled here, so the
+        // model-facing discovery flow below (and issue #161's fix) is unaffected. No rollout
+        // JSONL shape change; no parser change needed.
         "tool_search_call" => {
             // Search request — tool definitions arrive in the paired tool_search_call_output.
         }


### PR DESCRIPTION
## Summary

Codex v0.147.0 bumped the bundled MCP SDK to 3.0.0 (#36001) and added an opt-in MCP 2026-07-28 protocol revision (#35724, #35725, #35590, #35742). This PR verifies both concerns raised in #222 directly against the actual `openai/codex` source and confirms neither requires a parser change.

## What was verified

- **MCP SDK 3.0.0 bump (#36001) — verified not applicable.** The diff only renames internal SDK types (`Meta` → `MetaObject`) and improves OAuth transport error handling. No changes to `codex-rs/protocol` or rollout serialization.
- **MCP 2026-07-28 protocol (#35724, #35725, #35590, #35742) — verified not applicable.** These PRs change the wire protocol between Codex and MCP *servers*: paginated `server/discover` requests, multi-round `tools/call` negotiation, and non-blocking server startup. That pagination/negotiation is resolved internally by Codex before it ever builds the `dynamic_tools` field or tool-search results — none of the four PRs touch `codex-rs/protocol` (rollout item types), `app-server/src/dynamic_tools.rs`, or the model-facing `tool_search_call`/`tool_search_call_output` mechanism codex-trace already parses (issue #161's fix). The rollout JSONL shape is unchanged.

Documented this audit as a code comment in `turn.rs` next to the existing tool-search handling, following the same "verify against real upstream source, document non-applicable findings" pattern used in #213 for issue #210 — since both parts of #222 turned out to be non-applicable, there's no new field or parsing logic to add.

## Testing

- `cargo test` (360 tests): all pass
- `npx vitest run` (148 tests): all pass
- `cargo clippy -- -D warnings`: clean
- `tsc --noEmit`, `oxfmt --check`: clean
- `oxlint`: clean except one pre-existing, unrelated warning in `MarkdownRenderer.tsx`

Closes #222
