### PR TITLE
fix(parser): skip external-session-import sentinel in agent_message (#221)

### DIFF
--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -6,6 +6,15 @@ use super::entry::{parse_timestamp_secs, RawEntry};
 use super::spawn::parse_spawn_agent_output;
 use super::toolcall::{ToolCall, ToolCallBuilder};
 
+/// Codex's own sentinel text for a synthetic `agent_message` event it inserts at the end of
+/// the transcript it copies in from an imported Claude/Cursor conversation (pre-v0.140.0
+/// external-agent import feature). Codex v0.147.0 (PR #36356, issue #221) added support for
+/// syncing further edits into that same imported thread rather than creating a duplicate, so
+/// this marker can now sit mid-transcript — right before the newly-synced turns — instead of
+/// only ever trailing a finished import. It carries no real content and must never be
+/// rendered as an assistant message.
+const EXTERNAL_SESSION_IMPORTED_MARKER: &str = "<EXTERNAL SESSION IMPORTED>";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TurnStatus {
@@ -387,7 +396,7 @@ fn handle_event_msg(
                         .get("message")
                         .map(extract_message_text)
                         .unwrap_or_default();
-                    if !text.is_empty() {
+                    if !text.is_empty() && text != EXTERNAL_SESSION_IMPORTED_MARKER {
                         let phase = payload
                             .get("phase")
                             .and_then(|v| v.as_str())
@@ -4296,6 +4305,80 @@ mod tests {
         assert_eq!(
             turns[1].forked_from_thread_id.as_deref(),
             Some("turn-1-thread")
+        );
+    }
+
+    // Codex v0.147.0 (PR #36356, issue #221): syncing further edits into an already-imported
+    // Claude/Cursor conversation appends new turns after the existing `<EXTERNAL SESSION
+    // IMPORTED>` marker rather than creating a duplicate thread. The marker itself predates
+    // v0.147.0 (external-agent import, v0.140.0) but previously only ever trailed a finished
+    // import; it can now sit mid-transcript, so it must never surface as a real message.
+
+    #[test]
+    fn v0147_external_session_imported_marker_is_not_rendered_as_agent_message() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-08-05T10:00:00Z","type":"session_meta","payload":{"id":"v0147-import-marker","timestamp":"2026-08-05T10:00:00Z","cwd":"/project","cli_version":"0.147.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-08-05T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"external-import-turn-1"}}"#,
+            r#"{"timestamp":"2026-08-05T10:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"first imported request"}}"#,
+            r#"{"timestamp":"2026-08-05T10:00:03Z","type":"event_msg","payload":{"type":"agent_message","message":"first imported answer"}}"#,
+            r#"{"timestamp":"2026-08-05T10:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":"<EXTERNAL SESSION IMPORTED>"}}"#,
+            r#"{"timestamp":"2026-08-05T10:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"external-import-turn-1","completed_at":1785926405.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0]
+                .agent_messages
+                .iter()
+                .map(|m| m.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first imported answer"],
+            "the <EXTERNAL SESSION IMPORTED> marker must not appear as a rendered message"
+        );
+        assert_eq!(turns[0].final_answer, None);
+    }
+
+    #[test]
+    fn v0147_synced_turn_after_import_marker_parses_as_its_own_turn() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-08-05T11:00:00Z","type":"session_meta","payload":{"id":"v0147-synced-thread","timestamp":"2026-08-05T11:00:00Z","cwd":"/project","cli_version":"0.147.0","model_provider":"openai"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"external-import-turn-1"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:02Z","type":"event_msg","payload":{"type":"user_message","message":"imported request"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:03Z","type":"event_msg","payload":{"type":"agent_message","message":"imported answer"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:04Z","type":"event_msg","payload":{"type":"agent_message","message":"<EXTERNAL SESSION IMPORTED>"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:05Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"external-import-turn-1","completed_at":1785930005.0}}"#,
+            // Sync appends a genuinely new turn after the marker once the source conversation
+            // gains more messages upstream.
+            r#"{"timestamp":"2026-08-05T11:00:06Z","type":"event_msg","payload":{"type":"task_started","turn_id":"external-import-turn-2"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:07Z","type":"event_msg","payload":{"type":"user_message","message":"follow-up request added after sync"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:08Z","type":"event_msg","payload":{"type":"agent_message","message":"follow-up answer"}}"#,
+            r#"{"timestamp":"2026-08-05T11:00:09Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"external-import-turn-2","completed_at":1785930009.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 2);
+        assert_eq!(
+            turns[0]
+                .agent_messages
+                .iter()
+                .map(|m| m.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["imported answer"]
+        );
+        assert_eq!(
+            turns[1].user_message.as_deref(),
+            Some("follow-up request added after sync")
+        );
+        assert_eq!(
+            turns[1]
+                .agent_messages
+                .iter()
+                .map(|m| m.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["follow-up answer"]
         );
     }
 }


### PR DESCRIPTION
## What changed

Codex v0.147.0 (openai/codex PR #36356, part of #36361/#35623) lets Codex sync further edits into an already-imported Claude/Cursor conversation by appending new turns to the existing thread, instead of only ever finishing an import once.

I checked the real upstream diff (openai/codex#36356) rather than guessing:

- **Session-identity concern (the issue's main "open question"):** the sync path appends directly into the *same* rollout file for the *same* thread id — it never writes a new file or a new `session_meta`. codex-trace's existing `(mtime, size)` cache invalidation in `cache.rs` already re-parses on any change to that file, so no duplicate/orphaned session entries can appear and `discover.rs` needs no change here.
- **Real bug found instead:** Codex inserts a synthetic `agent_message` event with the sentinel text `<EXTERNAL SESSION IMPORTED>` as the last message of an imported thread (see `EXTERNAL_SESSION_IMPORTED_MARKER` in `codex-rs/external-agent-migration/src/sessions/export.rs`). Previously this sentinel only ever trailed a *finished* import. With v0.147.0's sync, it can now sit **mid-transcript**, right before newly-synced turns, since the append logic filters it out of the appended suffix but leaves the original one in place. `turn.rs` rendered any non-empty `agent_message` text as a real message, so this sentinel would show up as a fake assistant reply sitting between two real turns.

## Fix

Skip the exact sentinel string in `handle_event_msg` so it's never rendered as a message or picked up as a `final_answer`.

## Tests

Added two tests in `src-tauri/src/parser/turn.rs`:
- `v0147_external_session_imported_marker_is_not_rendered_as_agent_message` — the marker is suppressed and doesn't become the turn's final answer.
- `v0147_synced_turn_after_import_marker_parses_as_its_own_turn` — a turn appended after the marker (simulating a sync) still parses correctly as its own turn.

## Verification

- `cargo test --lib --manifest-path src-tauri/Cargo.toml` — 362 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — clean
- `npx vitest run` — 148 passed
- `npx tsc --noEmit` — clean
- `npx oxlint` — clean (one pre-existing, unrelated warning in `MarkdownRenderer.tsx`)

Fixes #221
