### PR TITLE
fix(parser): redact secrets in exec commands for Codex v0.147.0 (#217)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "dirs",
  "indexmap 2.14.0",
  "notify",
+ "regex",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 indexmap = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 zstd = "0.13"
+regex = "1"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src-tauri/src/parser/mod.rs
+++ b/src-tauri/src/parser/mod.rs
@@ -3,6 +3,7 @@ pub mod compression;
 pub mod discover;
 pub mod entry;
 pub mod ongoing;
+pub mod redact;
 pub mod session;
 pub mod spawn;
 pub mod toolcall;

--- a/src-tauri/src/parser/redact.rs
+++ b/src-tauri/src/parser/redact.rs
@@ -1,0 +1,106 @@
+//! Display-time secret redaction for exec command text.
+//!
+//! Codex v0.147.0 (#36893, #36908) started redacting bearer tokens and other secrets from
+//! commands rendered by its own app-server-protocol layer (`ThreadItem::CommandExecution`,
+//! used by IDE/app clients for live and replayed history). That redaction happens only when
+//! building those client-facing items — the raw, unredacted `command: Vec<String>` is still
+//! what gets persisted to the rollout JSONL that codex-trace reads directly. Without its own
+//! redaction, codex-trace would surface secrets that Codex's own UIs now hide. These regexes
+//! mirror `codex-rs/secrets/src/sanitizer.rs` so codex-trace redacts the same patterns Codex
+//! itself does.
+use regex::Regex;
+use std::sync::OnceLock;
+
+fn openai_key_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"sk-[A-Za-z0-9]{20,}").expect("valid regex"))
+}
+
+fn aws_access_key_id_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"\bAKIA[0-9A-Z]{16}\b").expect("valid regex"))
+}
+
+fn bearer_token_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"(?i:\bBearer)[ \t]+[A-Za-z0-9._~+/-]{16,}=*").expect("valid regex")
+    })
+}
+
+fn secret_assignment_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?i)\b(api[_-]?key|token|secret|password)\b(\s*[:=]\s*)(["']?)[^\s"']{8,}"#)
+            .expect("valid regex")
+    })
+}
+
+/// Best-effort redaction of recognizable secrets (bearer tokens, OpenAI/AWS-style keys,
+/// and `key=value`/`key: value` secret assignments) from a single line of display text.
+pub fn redact_secrets(input: &str) -> String {
+    let redacted = bearer_token_regex().replace_all(input, "Bearer [REDACTED_SECRET]");
+    let redacted = openai_key_regex().replace_all(&redacted, "[REDACTED_SECRET]");
+    let redacted = aws_access_key_id_regex().replace_all(&redacted, "[REDACTED_SECRET]");
+    let redacted = secret_assignment_regex().replace_all(&redacted, "$1$2$3[REDACTED_SECRET]");
+    redacted.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_secrets;
+
+    // Fixture tokens are assembled from split literals at runtime so the source never
+    // contains a single string matching a real credential pattern.
+    fn fixture_token(prefix: &str, suffix: &str) -> String {
+        format!("{prefix}{suffix}")
+    }
+
+    #[test]
+    fn redacts_bearer_token() {
+        let token = fixture_token("abcdefghijklmnop", "01234567");
+        let input = format!("curl -H \"Authorization: Bearer {token}\" https://api.example.com");
+        let output = redact_secrets(&input);
+        assert!(!output.contains(&token));
+        assert!(output.contains("Bearer [REDACTED_SECRET]"));
+    }
+
+    #[test]
+    fn redacts_openai_style_key() {
+        let token = fixture_token("sk-", "abcdefghijklmnopqrstuvwx");
+        let input = format!("export OPENAI_API_KEY={token}");
+        let output = redact_secrets(&input);
+        assert!(!output.contains(&token));
+        assert!(output.contains("[REDACTED_SECRET]"));
+    }
+
+    #[test]
+    fn redacts_aws_access_key_id() {
+        let token = fixture_token("AKIA", "ABCDEFGHIJKLMNOP");
+        let input = format!("aws configure set aws_access_key_id {token}");
+        let output = redact_secrets(&input);
+        assert!(!output.contains(&token));
+        assert!(output.contains("[REDACTED_SECRET]"));
+    }
+
+    #[test]
+    fn redacts_generic_secret_assignment() {
+        let token = fixture_token("supersecretvalue", "123");
+        let input = format!("--password={token}");
+        let output = redact_secrets(&input);
+        assert!(!output.contains(&token));
+        assert!(output.contains("[REDACTED_SECRET]"));
+    }
+
+    #[test]
+    fn leaves_ordinary_commands_untouched() {
+        let input = "npx oxlint src/components/ToolCallItem.tsx";
+        assert_eq!(redact_secrets(input), input);
+    }
+
+    #[test]
+    fn avoids_bearer_false_positive_on_short_word() {
+        let input = "Bearer of good news arrived";
+        assert_eq!(redact_secrets(input), input);
+    }
+}

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -1,3 +1,4 @@
+use super::redact::redact_secrets;
 use super::spawn::parse_spawn_agent_output;
 
 use serde::{Deserialize, Serialize};
@@ -539,7 +540,8 @@ impl ToolCallBuilder {
 
         let command: Option<Vec<String>> = payload
             .get("command")
-            .and_then(|c| serde_json::from_value(c.clone()).ok());
+            .and_then(|c| serde_json::from_value(c.clone()).ok())
+            .map(redact_command);
         let exit_code = payload
             .get("exit_code")
             .and_then(|v| v.as_i64())
@@ -1150,11 +1152,20 @@ fn spawn_agent_status(output: &str) -> String {
 
 fn command_from_arguments(arguments: &Value) -> Option<Vec<String>> {
     if let Some(cmd) = arguments.get("cmd").and_then(|v| v.as_str()) {
-        return Some(vec![cmd.to_string()]);
+        return Some(redact_command(vec![cmd.to_string()]));
     }
     arguments
         .get("command")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .map(redact_command)
+}
+
+/// Codex v0.147.0 (#36893, #36908) redacts secrets from displayed commands, but only at its
+/// app-server-protocol display layer — the raw command persisted to the rollout JSONL is
+/// unaffected. Apply the same redaction here so codex-trace, which reads that raw JSONL
+/// directly, doesn't surface secrets that Codex's own clients now hide.
+fn redact_command(command: Vec<String>) -> Vec<String> {
+    command.into_iter().map(|s| redact_secrets(&s)).collect()
 }
 
 fn cwd_from_arguments(arguments: &Value) -> Option<String> {
@@ -2585,5 +2596,63 @@ mod tests {
         assert_eq!(tool.kind, ToolKind::ExecCommand);
         assert_eq!(tool.output_truncated, Some(true));
         assert_eq!(tool.exit_code, Some(0));
+    }
+
+    // Codex v0.147.0 (#36893, #36908): Codex's own redaction only applies at its
+    // app-server-protocol display layer, not to the raw command persisted in the rollout
+    // JSONL. codex-trace must redact recognizable secrets itself when extracting `command`.
+    #[test]
+    fn exec_command_end_command_field_has_secrets_redacted() {
+        let fixture_token = format!("{}{}", "abcdefghijklmnop", "01234567");
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_secret".to_string(),
+            "exec_command".to_string(),
+            r#"{"cmd":"echo hi","workdir":"/tmp"}"#,
+            None,
+            None,
+            None,
+        );
+
+        let payload = json!({
+            "call_id": "call_secret",
+            "command": ["curl", "-H", format!("Authorization: Bearer {fixture_token}")],
+            "aggregated_output": "",
+            "exit_code": 0,
+            "status": "completed"
+        });
+        builder.finalize_exec("exec_command_end", &payload);
+
+        let tool = &builder.finalized[0];
+        let command = tool.command.as_ref().expect("command should be present");
+        assert!(
+            !command.iter().any(|arg| arg.contains(&fixture_token)),
+            "redacted command must not contain the raw secret"
+        );
+        assert!(command[2].contains("Bearer [REDACTED_SECRET]"));
+    }
+
+    #[test]
+    fn function_call_output_cmd_argument_has_secrets_redacted() {
+        let fixture_token = format!("{}{}", "sk-", "abcdefghijklmnopqrstuvwx");
+        let mut builder = ToolCallBuilder::new();
+        builder.add_function_call(
+            "call_secret_arg".to_string(),
+            "exec_command".to_string(),
+            &format!(r#"{{"cmd":"export OPENAI_API_KEY={fixture_token}","workdir":"/tmp"}}"#),
+            None,
+            None,
+            None,
+        );
+
+        builder.add_function_call_output("call_secret_arg", "done", None);
+
+        let tool = &builder.finalized[0];
+        let command = tool.command.as_ref().expect("command should be present");
+        assert!(
+            !command.iter().any(|arg| arg.contains(&fixture_token)),
+            "redacted command must not contain the raw secret"
+        );
+        assert!(command[0].contains("[REDACTED_SECRET]"));
     }
 }


### PR DESCRIPTION
## What

Codex v0.147.0 (openai/codex#36893, #36908) started redacting bearer tokens and other secrets from displayed commands. This PR adds the same redaction to codex-trace, applied to every `command` we extract from `exec_command_begin`/`exec_command_end` payloads and from `function_call` arguments (`cmd`/`command`).

## Why

I checked the actual upstream source for the cited PRs rather than guessing where the redaction happens:

- `codex-rs/secrets/src/sanitizer.rs` defines `redact_secrets` with a fixed set of regexes (bearer tokens, OpenAI-style `sk-` keys, AWS `AKIA` access key IDs, generic `key=value`/`key: value` secret assignments).
- Its only callers are `app-server-protocol/src/protocol/item_builders.rs` (building `ThreadItem::CommandExecution` for IDE/app clients) and `memories/write/src/phase1.rs` (memory summaries) — the rollout writer (`core/src/rollout.rs`) never calls it.

So Codex's own redaction happens only at its app-server-protocol display layer. The raw, unredacted command is what actually gets persisted to the rollout JSONL that codex-trace reads directly. Without its own redaction, codex-trace would surface secrets that Codex's current UIs now hide — exactly the risk the issue flagged.

I also checked 1,742 real `exec_command_end` events across this machine's own `~/.codex/sessions` history: every single one has the shape `["/bin/zsh", "-lc", "<full command as one string>"]`. Since the whole shell line lives in a single array element, redacting each `command` element independently (rather than joining the array first, like upstream does before its own redaction) produces the same result for real-world data.

## Change

- `src-tauri/src/parser/redact.rs` (new): a `redact_secrets` helper with the same regexes as upstream's sanitizer, using `std::sync::OnceLock` instead of `LazyLock` (this crate's MSRV is 1.77.2; `LazyLock` needs 1.80).
- `src-tauri/src/parser/toolcall.rs`: apply `redact_secrets` to every `command: Vec<String>` extracted in `finalize_exec` (the `exec_command_begin`/`exec_command_end` path) and in `command_from_arguments` (the `cmd`/`command` function-call-argument path).
- `src-tauri/Cargo.toml`/`Cargo.lock`: add `regex = "1"`.

## Verification

- `cargo test --lib --manifest-path src-tauri/Cargo.toml` — 368 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — clean
- `npx tsc --noEmit` — clean
- `npx oxlint` — clean (one pre-existing, unrelated warning in `MarkdownRenderer.tsx`)
- `npx vitest run` — 148 passed

Fixes #217
