### PR TITLE
test(parser): add max/ultra reasoning-effort regression fixtures (#239)

### DIFF
--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -2830,6 +2830,39 @@ mod tests {
         assert!(turns[0].reasoning_effort.is_none());
     }
 
+    // Codex v0.149.0 (PR #39662): "max" and "ultra" were added as valid reasoning-effort
+    // values alongside minimal/low/medium/high. reasoning_effort is stored as a plain
+    // Option<String> with no enum validation, so these new values must pass through
+    // unchanged from both turn_context and thread_settings payloads.
+    #[test]
+    fn turn_context_accepts_max_reasoning_effort() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"s-effort-max","timestamp":"2026-08-20T10:00:00Z"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:02Z","type":"turn_context","payload":{"model":"gpt-5.4","cwd":"/tmp","effort":"max"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755684003.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].reasoning_effort.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn thread_settings_accepts_ultra_reasoning_effort() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"s-effort-ultra","timestamp":"2026-08-20T10:00:00Z","cli_version":"0.149.0"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:02Z","type":"response_item","payload":{"type":"user_input","content":"Ship the feature"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:03Z","type":"response_item","payload":{"type":"thread_settings","model":"gpt-5.4","cwd":"/workspace","effort":"ultra"}}"#,
+            r#"{"timestamp":"2026-08-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755684004.0}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].reasoning_effort.as_deref(), Some("ultra"));
+    }
+
     // Codex v0.131.0 (PR #22268): collab_agent_spawn_end event payload field renamed
     // new_thread_id → new_session_id. Verify the parser reads new_session_id as a fallback.
     #[test]


### PR DESCRIPTION
## Summary

Codex v0.149.0 added `"max"` and `"ultra"` as new valid reasoning-effort values, alongside the existing `minimal`/`low`/`medium`/`high` (openai/codex#38817, openai/codex#39662).

codex-trace already stores `reasoning_effort` as a plain `Option<String>` end to end (`shared/types.ts`, `src-tauri/src/parser/turn.rs`), read verbatim from whichever payload field carries it (`reasoning_effort`, or the older `effort` key on `turn_context` / `thread_settings` / `user_input_with_turn_context`). There's no `deny_unknown_fields` or match against a fixed enum, so `"max"`/`"ultra"` already parse and render correctly — no production code change is needed.

A scan of `src/components` confirmed there's no dropdown/filter UI that hardcodes the four known effort levels — only test fixtures using fixed sample values, so there's nothing else to update there.

## Changes

- Added two regression tests in `src-tauri/src/parser/turn.rs` mirroring the existing reasoning-effort tests, covering `"max"` via `turn_context` and `"ultra"` via `thread_settings`, so a future change that adds strict validation to `reasoning_effort` gets caught by these fixtures.

## Test plan

- `cargo test --lib --manifest-path src-tauri/Cargo.toml` — 384 passed (including the 2 new tests)
- `npm test` (vitest + cargo test) — all passing
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean
- `npx tsc --noEmit`, `npx oxlint`, `npx oxfmt --check` — clean

Fixes #239
