### PR TITLE
test(compat): audit v0.149.0 queue-by-name resolution

### DIFF
--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -1788,4 +1788,93 @@ mod tests {
             .expect("session must be discovered even with an unrecognized section field");
         assert_eq!(session.cli_version.as_deref(), Some("0.147.0"));
     }
+
+    // Codex v0.149.0 (PR #39385): the TUI's queue-by-name command resolution now picks
+    // the most recently active session when multiple sessions share a queue name,
+    // instead of erroring on the ambiguity. codex-trace never resolves sessions by
+    // name — discovery reads one CodexSessionInfo per rollout file, identified solely
+    // by the `id` extracted from session_meta. `thread_name` (from `thread_name_updated`)
+    // is stored only as a display label and is never used to look up, merge, or
+    // deduplicate sessions. Verify two independent session files sharing the same
+    // thread_name are still discovered as two fully separate sessions, each keeping
+    // its own id — there is no name-based resolution path here for the upstream
+    // TUI behavior change to affect.
+    #[test]
+    fn v0149_duplicate_thread_name_sessions_remain_independent() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/20");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let older_path = day_dir.join("rollout-2026-08-20T09-00-00-v0149-older.jsonl");
+        std::fs::write(
+            &older_path,
+            [
+                r#"{"timestamp":"2026-08-20T09:00:00Z","type":"session_meta","payload":{"id":"v0149-older","timestamp":"2026-08-20T09:00:00Z","cwd":"/project","cli_version":"0.149.0"}}"#,
+                r#"{"timestamp":"2026-08-20T09:00:01Z","type":"event_msg","payload":{"type":"thread_name_updated","thread_name":"shared-queue-name"}}"#,
+                r#"{"timestamp":"2026-08-20T09:00:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T09:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755680403.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let newer_path = day_dir.join("rollout-2026-08-20T10-00-00-v0149-newer.jsonl");
+        std::fs::write(
+            &newer_path,
+            [
+                r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"v0149-newer","timestamp":"2026-08-20T10:00:00Z","cwd":"/project","cli_version":"0.149.0"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"thread_name_updated","thread_name":"shared-queue-name"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:02Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:03Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755684003.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        assert_eq!(sessions.len(), 2);
+
+        let older = sessions.iter().find(|s| s.id == "v0149-older").unwrap();
+        let newer = sessions.iter().find(|s| s.id == "v0149-newer").unwrap();
+        assert_eq!(older.thread_name.as_deref(), Some("shared-queue-name"));
+        assert_eq!(newer.thread_name.as_deref(), Some("shared-queue-name"));
+    }
+
+    // Codex v0.149.0 (PR #39034): queued messages written by another process can now
+    // be dispatched into a session's rollout file. Whichever session's file receives
+    // the dispatched message, codex-trace still discovers/attributes it correctly:
+    // discovery is driven purely by the file's own on-disk content (id, turns, thread
+    // name), not by which process authored a given line. Simulate a queued message
+    // landing as an additional turn appended to an already-active session's rollout
+    // and verify it is folded into that same session, not lost or misattributed.
+    #[test]
+    fn v0149_queued_message_appended_to_existing_session_is_attributed_correctly() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/20");
+        std::fs::create_dir_all(&day_dir).unwrap();
+
+        let path = day_dir.join("rollout-2026-08-20T11-00-00-v0149-target.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-20T11:00:00Z","type":"session_meta","payload":{"id":"v0149-target","timestamp":"2026-08-20T11:00:00Z","cwd":"/project","cli_version":"0.149.0"}}"#,
+                r#"{"timestamp":"2026-08-20T11:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T11:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755687602.0}}"#,
+                // Message queued by another process, dispatched once this session picked it up.
+                r#"{"timestamp":"2026-08-20T11:05:00Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"}}"#,
+                r#"{"timestamp":"2026-08-20T11:05:01Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-2","completed_at":1755687901.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        assert_eq!(sessions.len(), 1);
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0149-target")
+            .expect("queued-into session must still be discovered by its own id");
+        assert_eq!(session.turn_count, 2);
+        assert!(!session.is_ongoing);
+    }
 }


### PR DESCRIPTION
## What

Codex v0.149.0 changed TUI queue-by-name resolution (PR #39385): when multiple sessions share a queue name, the TUI now picks the most recently active session instead of erroring on the ambiguity. A related change (PR #39034) lets queued messages written by another process get dispatched into a session's rollout file, and PR #39604 preserves existing queued-input semantics around this. This adds regression tests auditing that codex-trace is unaffected.

## Why

codex-trace never resolves sessions by name at all. Session discovery (`discover_sessions` in `src-tauri/src/parser/discover.rs`) reads one entry per rollout file, identified solely by the `id` extracted from `session_meta` — never by a queue/thread name. The only name-like field, `thread_name` (set via `thread_name_updated` events), is stored purely as a display label and is never used for lookup, merge, or deduplication. So there is no code path in this repo for the upstream TUI name-resolution change to break.

The other half of the change — queued messages dispatched into a session's rollout file by another process — also doesn't need special handling: discovery and turn attribution are driven entirely by the file's own on-disk content (whatever entries land in a given rollout file get folded into that session), independent of which process wrote them.

## Change

- `src-tauri/src/parser/discover.rs`: added two regression tests —
  - `v0149_duplicate_thread_name_sessions_remain_independent`: two session files sharing the same `thread_name` are still discovered as two fully independent sessions, each keeping its own `id`.
  - `v0149_queued_message_appended_to_existing_session_is_attributed_correctly`: a message appended to an existing session's rollout file (simulating another-process queued dispatch) is correctly folded into that same session's turn count rather than lost or misattributed.

This follows the repo's established pattern for "no functional impact" Codex compat audits (e.g. `v0147_full_auto_flag_removal_does_not_affect_session_meta_parsing`) — a version-scoped regression test rather than a docs-only note.

## Verification

- `cargo test --lib --manifest-path src-tauri/Cargo.toml` — 381 tests pass (including the 2 new v0149 tests)
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` — clean
- `npm test` (vitest + cargo test) — 154 vitest + 381 cargo unit + 3 ACL tests pass
- `npx tsc --noEmit`, `npx oxfmt` — clean
- `npx oxlint` — clean (one pre-existing unrelated warning in `MarkdownRenderer.tsx`, not touched by this change)

Fixes #241
