### PR TITLE
[Compat] v0.149.0: TUI replay buffer cap — codex-trace unaffected (#240)

### DIFF
--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -4392,4 +4392,72 @@ mod tests {
             vec!["follow-up answer"]
         );
     }
+
+    // Codex v0.149.0 (PR #39081, upstream openai/codex): the TUI's in-memory
+    // per-thread replay buffer now caps buffered `AgentMessageDelta` bytes at
+    // 256 KiB per thread (`MAX_BUFFERED_AGENT_MESSAGE_DELTA_BYTES`), evicting the
+    // oldest buffered deltas once that total is exceeded, and coalesces
+    // consecutive same-item deltas into merged buffered entries capped at 4 KiB
+    // each (`MAX_COALESCED_AGENT_MESSAGE_DELTA_BYTES`). This bound lives entirely
+    // in `codex-rs/tui/src/app/thread_event_buffer.rs` — it governs only what the
+    // live TUI keeps in memory to replay when a user switches back to an inactive
+    // thread. codex-trace never reads that in-memory buffer; it parses the
+    // on-disk rollout JSONL directly, where Codex core still writes the
+    // fully-assembled `agent_message` event with the complete text once
+    // streaming finishes. Any intermediate `agent_message_delta` events recorded
+    // in the JSONL are already ignored by the wildcard arm in `handle_event_msg`
+    // (same as `outputDelta` in v0.129.0), so they can never truncate the final
+    // message either. Verify a message exceeding the 256 KiB TUI eviction
+    // threshold still parses in full, with no truncation, even when interleaved
+    // with delta events that would have overflowed the TUI's live buffer.
+    #[test]
+    fn v0149_agent_message_delta_replay_buffer_cap_does_not_truncate_full_message() {
+        let full_text = "a".repeat(300 * 1024); // 300 KiB, exceeds the 256 KiB TUI cap
+        let delta_chunk = "b".repeat(8 * 1024); // exceeds the 4 KiB per-entry coalesce cap
+
+        let session_meta = r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"v0149-session","timestamp":"2026-08-20T10:00:00Z","cwd":"/project","cli_version":"0.149.0","model_provider":"openai"}}"#.to_string();
+        let task_started = r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#.to_string();
+        // Oversized delta events, as would have been evicted from the TUI's
+        // in-memory replay buffer once their combined size passed 256 KiB.
+        let delta_lines: Vec<String> = (0..40)
+            .map(|i| {
+                let mut line = String::from(
+                    r#"{"timestamp":"2026-08-20T10:00:02Z","type":"event_msg","payload":{"type":"agent_message_delta","item_id":"item-1","delta":""#,
+                );
+                line.push_str(&delta_chunk);
+                line.push_str(r#"","seq":"#);
+                line.push_str(&i.to_string());
+                line.push_str("}}");
+                line
+            })
+            .collect();
+        let agent_message = {
+            let mut line = String::from(
+                r#"{"timestamp":"2026-08-20T10:00:03Z","type":"event_msg","payload":{"type":"agent_message","message":""#,
+            );
+            line.push_str(&full_text);
+            line.push_str(r#"","phase":"final_answer"}}"#);
+            line
+        };
+        let task_complete = r#"{"timestamp":"2026-08-20T10:00:04Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1755683044.0}}"#.to_string();
+
+        let mut lines: Vec<&str> = vec![&session_meta, &task_started];
+        lines.extend(delta_lines.iter().map(|s| s.as_str()));
+        lines.push(&agent_message);
+        lines.push(&task_complete);
+
+        let entries = entries(&lines);
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(
+            turns[0].agent_messages.len(),
+            1,
+            "delta events must not produce separate agent messages"
+        );
+        assert_eq!(turns[0].agent_messages[0].text.len(), 300 * 1024);
+        assert_eq!(turns[0].agent_messages[0].text, full_text);
+        assert!(turns[0].agent_messages[0].text.len() > 256 * 1024);
+        assert_eq!(turns[0].final_answer.as_deref(), Some(full_text.as_str()));
+    }
 }


### PR DESCRIPTION
## Summary

Codex v0.149.0 (upstream [openai/codex#39081](https://github.com/openai/codex/pull/39081)) adds a byte-size cap to the Codex TUI's in-memory per-thread replay buffer:

- `MAX_BUFFERED_AGENT_MESSAGE_DELTA_BYTES` (256 KiB) — evicts the oldest buffered `AgentMessageDelta` events once total buffered bytes for a thread exceed this.
- `MAX_COALESCED_AGENT_MESSAGE_DELTA_BYTES` (4 KiB) — caps how large a single coalesced buffered entry can grow.

This buffer only governs what the live TUI keeps in memory to replay an inactive/resumed thread. codex-trace never reads that in-memory buffer — it parses the on-disk rollout JSONL directly, and the full, fully-assembled `agent_message` event Codex core writes to disk is unaffected by what the TUI chooses to keep buffered for its own display purposes.

## Investigation

- Confirmed `handle_event_msg` in `src-tauri/src/parser/turn.rs` has no code path that reads `agent_message_delta` events at all — they fall through the wildcard arm (`_ => {}`), same treatment as other removed/live-only event types from prior compat audits (e.g. v0.129.0's `outputDelta`).
- The only agent-message text codex-trace reads is the fully-assembled `agent_message` event's `message` field (or the assistant `message` response_item), taken verbatim — no delta concatenation, no truncation logic exists in codex-trace.
- No shared code path with `codex-rs/tui/src/app/thread_event_buffer.rs`, `thread_events.rs`, or `background_requests.rs` exists in this repo.

## Fix

No parser change was needed — this issue is a "no code change" case per the issue's own suggested fix. Added a regression fixture per the repo's established compat-audit convention (see `v0129_removed_item_file_change_and_output_delta_events_ignored_gracefully`, `v0147_full_auto_flag_removal_does_not_affect_session_meta_parsing`, etc.):

- `v0149_agent_message_delta_replay_buffer_cap_does_not_truncate_full_message` in `src-tauri/src/parser/turn.rs` builds a session with a 300 KiB `agent_message` (exceeding the 256 KiB TUI cap) interleaved with 40 oversized `agent_message_delta` events (each exceeding the 4 KiB coalesce cap), and asserts the full, untruncated text is captured as the turn's final answer.

Fixes #240

## Test plan

- `cargo test --lib --manifest-path src-tauri/Cargo.toml` — 380 passed
- `cargo test --manifest-path src-tauri/Cargo.toml` (incl. `acl_consistency` integration tests) — all passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — clean
- `npx vitest run` — 154 passed (14 files)
- `npx tsc --noEmit` — clean
- `npx oxlint` — clean (one pre-existing, unrelated warning in `MarkdownRenderer.tsx`, not touched by this change)
- `npx oxfmt --check` — clean
