### PR TITLE
Surface session_meta.forked_from_id for codex exec fork/resume sessions

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -252,6 +252,14 @@ export interface CodexSession {
    * the whole rollout file as a continuation of another paginated thread's history.
    * Null for legacy-history sessions or paginated threads with no inherited prefix. */
   history_base_thread_id: string | null;
+  /** Thread ID this session was forked from, read from `session_meta.payload.forked_from_id`
+   * — the app-server's `SessionConfiguredEvent.forked_from_id`, persisted verbatim into the
+   * rollout's `session_meta` line. This field predates Codex v0.148.0, but `codex exec fork`
+   * (new subcommand) and `codex exec resume` (Codex v0.148.0+, PR #37367, issue #238) are the
+   * first `codex exec` code paths to populate it — previously hardcoded to `null` there.
+   * Session-level signal, distinct from the per-turn `forked_from_thread_id` on `CodexTurn`.
+   * Null for non-forked sessions. */
+  forked_from_thread_id: string | null;
 }
 
 export interface CodexSessionInfo {
@@ -296,6 +304,14 @@ export interface CodexSessionInfo {
    * the whole rollout file as a continuation of another paginated thread's history.
    * Null for legacy-history sessions or paginated threads with no inherited prefix. */
   history_base_thread_id: string | null;
+  /** Thread ID this session was forked from, read from `session_meta.payload.forked_from_id`
+   * — the app-server's `SessionConfiguredEvent.forked_from_id`, persisted verbatim into the
+   * rollout's `session_meta` line. This field predates Codex v0.148.0, but `codex exec fork`
+   * (new subcommand) and `codex exec resume` (Codex v0.148.0+, PR #37367, issue #238) are the
+   * first `codex exec` code paths to populate it — previously hardcoded to `null` there.
+   * Session-level signal, distinct from the per-turn `forked_from_thread_id` on `CodexTurn`.
+   * Null for non-forked sessions. */
+  forked_from_thread_id: string | null;
 }
 
 export interface SettingsResponse {

--- a/src-tauri/src/parser/discover.rs
+++ b/src-tauri/src/parser/discover.rs
@@ -57,6 +57,16 @@ pub struct CodexSessionInfo {
     /// marks a whole rollout file as a continuation of another paginated thread's history.
     /// Null for legacy-history sessions or paginated threads with no inherited prefix.
     pub history_base_thread_id: Option<String>,
+    /// Thread ID this session was forked from, read from `session_meta.payload.forked_from_id`
+    /// — the app-server's `SessionConfiguredEvent.forked_from_id`, persisted verbatim into the
+    /// rollout's `session_meta` line by `codex-rs/rollout/src/recorder.rs`. This field on
+    /// `SessionMeta` predates Codex v0.148.0, but `codex exec fork` (new subcommand) and
+    /// `codex exec resume` (Codex v0.148.0+, PR #37367, issue #238) are the first `codex exec`
+    /// code paths to populate it — it was previously hardcoded to `None` in
+    /// `codex-rs/exec/src/lib.rs`. Session-level signal, distinct from the per-turn
+    /// `forked_from_thread_id` on `CodexTurn` (sourced from `task_started`).
+    /// Null for non-forked sessions.
+    pub forked_from_thread_id: Option<String>,
 }
 
 /// Scan a sessions directory recursively for all rollout-*.jsonl files.
@@ -221,6 +231,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         meta_archived,
         approval_mode,
         history_base_thread_id,
+        forked_from_thread_id,
     ) = match entry.entry_type.as_str() {
         "session_meta" => {
             let id = extract_session_id(payload);
@@ -279,6 +290,16 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string());
+            // Codex v0.148.0 (PR #37367, issue #238): session_meta.forked_from_id is the
+            // app-server's SessionConfiguredEvent.forked_from_id, persisted verbatim into the
+            // rollout. Verified against codex-rs/rollout/src/recorder.rs and
+            // codex-rs/protocol/src/protocol.rs's SessionMeta struct — real signal for any
+            // forked or fork-descended thread, including codex exec fork/resume sessions.
+            let forked_from_thread_id = payload
+                .get("forked_from_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
             (
                 id,
                 start_time,
@@ -295,6 +316,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 meta_archived,
                 approval_mode,
                 history_base_thread_id,
+                forked_from_thread_id,
             )
         }
         "session_meta_root" => {
@@ -307,7 +329,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
                 .map(|s| s.to_string());
             (
                 id, start_time, None, None, None, git_branch, None, false, false, None, None, None,
-                false, None, None,
+                false, None, None, None,
             )
         }
         _ => return None,
@@ -553,6 +575,7 @@ fn scan_session_file(path: &Path) -> Option<CodexSessionInfo> {
         ai_title,
         approval_mode,
         history_base_thread_id,
+        forked_from_thread_id,
     })
 }
 
@@ -1787,5 +1810,90 @@ mod tests {
             .find(|s| s.id == "v0147-section")
             .expect("session must be discovered even with an unrecognized section field");
         assert_eq!(session.cli_version.as_deref(), Some("0.147.0"));
+    }
+
+    // Codex v0.148.0/v0.149.0 (PRs #37367, #38819, issue #238): `codex exec fork` and
+    // `codex exec resume` populate the app-server's SessionConfiguredEvent.forked_from_id
+    // (previously hardcoded to None in codex-rs/exec/src/lib.rs). That value is persisted
+    // verbatim into the rollout's session_meta.forked_from_id field by
+    // codex-rs/rollout/src/recorder.rs for any forked or fork-descended thread — this is a
+    // distinct, session-level signal from the per-turn task_started.forked_from_thread_id
+    // field. discover_sessions must surface it so fork lineage from `codex exec fork` is
+    // detected even when no per-turn signal is present.
+
+    #[test]
+    fn discover_sessions_v0148_reads_forked_from_id_for_exec_fork() {
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/20");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-20T10-00-00-v0148-exec-fork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"v0148-exec-fork-child","timestamp":"2026-08-20T10:00:00Z","cwd":"/project","cli_version":"0.148.0","model_provider":"openai","originator":"codex_exec","forked_from_id":"v0148-exec-fork-parent"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1787306402.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0148-exec-fork-child")
+            .expect("codex exec fork session must be discovered");
+        assert_eq!(
+            session.forked_from_thread_id.as_deref(),
+            Some("v0148-exec-fork-parent"),
+            "session_meta.forked_from_id must be surfaced as forked_from_thread_id even with \
+             no task_started.forked_from_thread_id present"
+        );
+    }
+
+    #[test]
+    fn discover_sessions_no_forked_from_id_is_none() {
+        // Non-forked sessions (the vast majority) must not set forked_from_thread_id.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/20");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-20T10-01-00-v0148-nofork.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"timestamp":"2026-08-20T10:01:00Z","type":"session_meta","payload":{"id":"v0148-nofork","timestamp":"2026-08-20T10:01:00Z","cwd":"/project","cli_version":"0.148.0","model_provider":"openai"}}"#,
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0148-nofork")
+            .expect("session must be discovered");
+        assert!(
+            session.forked_from_thread_id.is_none(),
+            "session without forked_from_id must have forked_from_thread_id == None"
+        );
+    }
+
+    #[test]
+    fn discover_sessions_empty_forked_from_id_is_none() {
+        // Defensive: an empty-string forked_from_id must be treated as absent, not surfaced
+        // as a bogus lineage pointer.
+        let tmp = tempdir().unwrap();
+        let day_dir = tmp.path().join("2026/08/20");
+        std::fs::create_dir_all(&day_dir).unwrap();
+        let path = day_dir.join("rollout-2026-08-20T10-02-00-v0148-empty-fork.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"timestamp":"2026-08-20T10:02:00Z","type":"session_meta","payload":{"id":"v0148-empty-fork","timestamp":"2026-08-20T10:02:00Z","cli_version":"0.148.0","forked_from_id":""}}"#,
+        )
+        .unwrap();
+
+        let sessions = discover_sessions(tmp.path()).unwrap();
+        let session = sessions
+            .iter()
+            .find(|s| s.id == "v0148-empty-fork")
+            .expect("session must be discovered even with an empty forked_from_id");
+        assert!(session.forked_from_thread_id.is_none());
     }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -48,6 +48,16 @@ pub struct CodexSession {
     /// marks the whole rollout file as a continuation of another paginated thread's history.
     /// Null for legacy-history sessions or paginated threads with no inherited prefix.
     pub history_base_thread_id: Option<String>,
+    /// Thread ID this session was forked from, read from `session_meta.payload.forked_from_id`
+    /// — the app-server's `SessionConfiguredEvent.forked_from_id`, persisted verbatim into the
+    /// rollout's `session_meta` line by `codex-rs/rollout/src/recorder.rs`. This field on
+    /// `SessionMeta` predates Codex v0.148.0, but `codex exec fork` (new subcommand) and
+    /// `codex exec resume` (Codex v0.148.0+, PR #37367, issue #238) are the first `codex exec`
+    /// code paths to populate it — it was previously hardcoded to `None` in
+    /// `codex-rs/exec/src/lib.rs`. Session-level signal, distinct from the per-turn
+    /// `forked_from_thread_id` on `CodexTurn` (sourced from `task_started`).
+    /// Null for non-forked sessions.
+    pub forked_from_thread_id: Option<String>,
 }
 
 /// Parse a Codex JSONL session file into a CodexSession.
@@ -94,6 +104,7 @@ fn parse_session_inner(
         is_headless: false,
         has_missing_spawn_metadata: false,
         history_base_thread_id: None,
+        forked_from_thread_id: None,
     };
 
     // Parse session_meta from first matching entry
@@ -316,6 +327,17 @@ fn parse_session_meta_new(session: &mut CodexSession, payload: &Value, _raw: &Va
     session.history_base_thread_id = payload
         .get("history_base")
         .and_then(|b| b.get("thread_id"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+
+    // Codex v0.148.0 (PR #37367, issue #238): session_meta.forked_from_id is the
+    // app-server's SessionConfiguredEvent.forked_from_id, persisted verbatim into the
+    // rollout. Verified against codex-rs/rollout/src/recorder.rs and
+    // codex-rs/protocol/src/protocol.rs's SessionMeta struct — real signal for any forked
+    // or fork-descended thread, including codex exec fork/resume sessions.
+    session.forked_from_thread_id = payload
+        .get("forked_from_id")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
@@ -1899,6 +1921,60 @@ mod tests {
 
         let session = parse_session(&path).unwrap();
         assert!(session.history_base_thread_id.is_none());
+    }
+
+    // Codex v0.148.0/v0.149.0 (PRs #37367, #38819, issue #238): `codex exec fork` and
+    // `codex exec resume` populate the app-server's SessionConfiguredEvent.forked_from_id
+    // (previously hardcoded to None in codex-rs/exec/src/lib.rs). That value is persisted
+    // verbatim into the rollout's session_meta.forked_from_id field by
+    // codex-rs/rollout/src/recorder.rs for any forked or fork-descended thread — a distinct,
+    // session-level signal from the per-turn task_started.forked_from_thread_id field.
+
+    #[test]
+    fn v0148_parse_session_reads_forked_from_id_for_exec_fork() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-08-20T10-00-00-v0148execfork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-20T10:00:00Z","type":"session_meta","payload":{"id":"v0148-exec-fork-child","timestamp":"2026-08-20T10:00:00Z","cwd":"/project","cli_version":"0.148.0","model_provider":"openai","originator":"codex_exec","forked_from_id":"v0148-exec-fork-parent"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T10:00:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1787306402.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert_eq!(
+            session.forked_from_thread_id.as_deref(),
+            Some("v0148-exec-fork-parent"),
+            "session_meta.forked_from_id must be surfaced as forked_from_thread_id even with \
+             no task_started.forked_from_thread_id present"
+        );
+    }
+
+    #[test]
+    fn v0148_parse_session_no_forked_from_id_is_none() {
+        let tmp = tempdir().unwrap();
+        let path = tmp
+            .path()
+            .join("rollout-2026-08-20T10-01-00-v0148nofork.jsonl");
+        std::fs::write(
+            &path,
+            [
+                r#"{"timestamp":"2026-08-20T10:01:00Z","type":"session_meta","payload":{"id":"v0148-nofork","timestamp":"2026-08-20T10:01:00Z","cwd":"/project","cli_version":"0.148.0","model_provider":"openai"}}"#,
+                r#"{"timestamp":"2026-08-20T10:01:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+                r#"{"timestamp":"2026-08-20T10:01:02Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1","completed_at":1787306462.0}}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_session(&path).unwrap();
+        assert!(session.forked_from_thread_id.is_none());
     }
 
     // Codex v0.146.0 (issue #211): the new skills subsystem renders the skill catalog into

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -180,6 +180,7 @@ mod tests {
                     ai_title: None,
                     approval_mode: None,
                     history_base_thread_id: None,
+                    forked_from_thread_id: None,
                 }],
             });
         }
@@ -227,6 +228,7 @@ mod tests {
                     ai_title: None,
                     approval_mode: None,
                     history_base_thread_id: None,
+                    forked_from_thread_id: None,
                 }],
             });
         }

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -36,6 +36,7 @@ function makeSession(overrides: Partial<CodexSession> = {}): CodexSession {
     is_archived: false,
     approval_mode: null,
     history_base_thread_id: null,
+    forked_from_thread_id: null,
     ...overrides,
   };
 }

--- a/src/components/SidebarTree.test.tsx
+++ b/src/components/SidebarTree.test.tsx
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     is_archived: false,
     approval_mode: null,
     history_base_thread_id: null,
+    forked_from_thread_id: null,
     worker_nickname: null,
     worker_role: null,
     spawned_worker_ids: [],

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -86,6 +86,7 @@ function makeWorkerSession(toolCalls: CodexToolCall[]): CodexSession {
     is_archived: false,
     approval_mode: null,
     history_base_thread_id: null,
+    forked_from_thread_id: null,
   };
 }
 

--- a/src/components/WorkerPanel.test.tsx
+++ b/src/components/WorkerPanel.test.tsx
@@ -89,6 +89,7 @@ function makeSession(toolCalls: CodexToolCall[]): CodexSession {
     is_archived: false,
     approval_mode: null,
     history_base_thread_id: null,
+    forked_from_thread_id: null,
   };
 }
 

--- a/src/lib/sessionDisplay.test.ts
+++ b/src/lib/sessionDisplay.test.ts
@@ -23,6 +23,7 @@ function makeSession(overrides: Partial<CodexSessionInfo> = {}): CodexSessionInf
     is_archived: false,
     approval_mode: null,
     history_base_thread_id: null,
+    forked_from_thread_id: null,
     worker_nickname: null,
     worker_role: null,
     spawned_worker_ids: [],


### PR DESCRIPTION
## Summary

Codex v0.148.0's PR openai/codex#37367 ("Add session forking to `codex exec`") added a new `codex exec fork <SESSION_ID> [PROMPT]` subcommand and, as a side effect, started populating the app-server's `SessionConfiguredEvent.forked_from_id` for `codex exec fork`/`codex exec resume` sessions — previously hardcoded to `None` in `codex-rs/exec/src/lib.rs`.

I confirmed against the upstream `openai/codex` source (`codex-rs/rollout/src/recorder.rs`, `codex-rs/protocol/src/protocol.rs`'s `SessionMeta` struct, checked at both the `rust-v0.135.0` and `rust-v0.149.0` tags) that this value is persisted verbatim into every rollout's `session_meta.forked_from_id` field for any forked or fork-descended thread. codex-trace never parsed this field.

Notably, this is a **more reliable** signal than the fork-detection codex-trace already had: the existing per-turn `task_started.forked_from_thread_id` read in `turn.rs` (added for issue #86 back in v0.135.0) targets a field that the real `TurnStartedEvent` struct never actually carries, in any Codex version I checked. That existing code path is harmless (always resolves to `None` on real sessions) but effectively dead. I left it untouched since fixing that is out of scope for this issue — this PR adds the field that actually works.

`codex-rs/thread-store` PR openai/codex#38819 ("Support metadata staging for reserved thread IDs") was also named in the issue as a possible second source of change. I checked its diff directly: it touches only `codex-rs/core/src/thread_manager.rs`, `codex-rs/thread-store/src/local/*` and SQLite state-store tests — no `codex-rs/rollout/*` file is touched. Confirmed no rollout/parser impact; no code change needed for it.

## Changes

- `src-tauri/src/parser/discover.rs`: added `CodexSessionInfo.forked_from_thread_id`, parsed from `session_meta.payload.forked_from_id` in `scan_session_file`.
- `src-tauri/src/parser/session.rs`: added `CodexSession.forked_from_thread_id`, parsed from `session_meta.payload.forked_from_id` in `parse_session_meta_new`.
- `shared/types.ts`: mirrored the new field on both `CodexSession` and `CodexSessionInfo`.
- `src-tauri/src/state.rs` and 5 frontend test fixtures: updated to include the new required field (mirrors the existing `history_base_thread_id` pattern).
- Added 5 new Rust regression tests covering: a `codex exec fork`-shaped session, a non-forked session, and an empty-string `forked_from_id` (must not be surfaced as a bogus lineage pointer).

This is a session-level signal (parsed once from `session_meta`, applies to the whole session), distinct from the existing per-turn `CodexTurn.forked_from_thread_id` field — same pattern already used for `history_base_thread_id`.

## Verification

- `cargo test` (Rust, 384 tests) — all pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `npx tsc --noEmit` — clean
- `npx oxlint` — clean (one pre-existing, unrelated warning in `MarkdownRenderer.tsx`)
- `npx oxfmt --check` — clean
- `npx vitest run` (154 tests) — all pass
- `npm run check` (full gate) — all pass

Fixes #238
