### PR TITLE
test(parser): verify Interrupt hook events render generically (#251)

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -885,6 +885,21 @@ mod tests {
         assert!(e.payload.get("stderr").is_none());
     }
 
+    // Codex v0.150.0 (PR #40511): a new `Interrupt` variant was added to the HookEventName
+    // enum — it fires for an active turn just before its interrupted-abort event, flushing
+    // the turn transcript first. codex-trace's shell_hook_output schema carries the hook
+    // event name as a free-form `hook_type` string (see #104, #107), so the new value must
+    // parse the same way existing hook_type values (pre_exec, post_exec, pre_mcp) do.
+
+    #[test]
+    fn v0150_interrupt_hook_output_parses_as_event_msg() {
+        let line = r#"{"timestamp":"2026-08-01T10:00:00Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-interrupt-1","hook_type":"interrupt","stdout":"turn interrupted\n","exit_code":0}}"#;
+        let e = RawEntry::parse(line).expect("interrupt shell_hook_output event must parse");
+        assert_eq!(e.entry_type, "event_msg");
+        assert_eq!(event_msg_type(&e.payload), Some("shell_hook_output"));
+        assert_eq!(e.payload["hook_type"], "interrupt");
+    }
+
     // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` produces structured
     // JSON output items. A "structured_output" response_item carries a JSON-validated
     // content object as its payload. RawEntry must parse these without panicking.

--- a/src-tauri/src/parser/toolcall.rs
+++ b/src-tauri/src/parser/toolcall.rs
@@ -2127,6 +2127,49 @@ mod tests {
         assert_eq!(tc.status, "completed");
     }
 
+    // Codex v0.150.0 (PR #40511): new `Interrupt` variant added to the HookEventName enum.
+    // hook_type is read as a free-form string (no fixed/exhaustive match against known hook
+    // names), so new and future hook event names classify as ShellHook the same way existing
+    // ones do — nothing to special-case.
+
+    #[test]
+    fn shell_hook_output_v0150_interrupt_hook_classified_as_shell_hook() {
+        let mut builder = ToolCallBuilder::new();
+        let payload = json!({
+            "call_id": "hook-interrupt-1",
+            "hook_type": "interrupt",
+            "stdout": "turn interrupted\n",
+            "exit_code": 0
+        });
+        builder.finalize_shell_hook(&payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tc = &builder.finalized[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "interrupt");
+        assert_eq!(tc.output.as_deref(), Some("turn interrupted\n"));
+        assert_eq!(tc.status, "completed");
+    }
+
+    #[test]
+    fn shell_hook_output_unrecognized_future_hook_name_still_classified_as_shell_hook() {
+        // No hook_type value is matched exhaustively, so a name codex-trace has never seen
+        // before must still classify as ShellHook rather than being dropped or erroring.
+        let mut builder = ToolCallBuilder::new();
+        let payload = json!({
+            "call_id": "hook-future-1",
+            "hook_type": "some_future_hook_name",
+            "stdout": "ran\n",
+            "exit_code": 0
+        });
+        builder.finalize_shell_hook(&payload);
+
+        assert_eq!(builder.finalized.len(), 1);
+        let tc = &builder.finalized[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "some_future_hook_name");
+    }
+
     // Codex v0.135.0 (PR #24652): plain image wrapper spans removed from session output.
     // Image content is now emitted bare (e.g. {"type":"image_url",...}) rather than wrapped
     // in {"type":"image_span","content":[...]}. The image_generation function call must be

--- a/src-tauri/src/parser/turn.rs
+++ b/src-tauri/src/parser/turn.rs
@@ -3415,6 +3415,32 @@ mod tests {
         assert_eq!(turns[0].tool_calls[0].kind, ToolKind::ShellHook);
     }
 
+    // Codex v0.150.0 (PR #40511): new `Interrupt` HookEventName variant fires for an active
+    // top-level turn just before its interrupted-abort event (turn_aborted), flushing the
+    // turn transcript first. The hook's shell_hook_output event must still be attached to the
+    // turn's tool_calls even though the turn ends as Aborted rather than Complete.
+
+    #[test]
+    fn v0150_interrupt_hook_flushes_transcript_before_turn_aborted() {
+        let entries = entries(&[
+            r#"{"timestamp":"2026-08-01T10:00:00Z","type":"session_meta","payload":{"id":"v0150-interrupt","timestamp":"2026-08-01T10:00:00Z","cli_version":"0.150.0"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:01Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:02Z","type":"event_msg","payload":{"type":"shell_hook_output","call_id":"hook-interrupt-1","hook_type":"interrupt","stdout":"turn interrupted\n","exit_code":0}}"#,
+            r#"{"timestamp":"2026-08-01T10:00:03Z","type":"event_msg","payload":{"type":"turn_aborted","turn_id":"turn-1","reason":"user_interrupt"}}"#,
+        ]);
+
+        let turns = build_turns(&entries);
+
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].status, TurnStatus::Aborted);
+        assert_eq!(turns[0].aborted_reason.as_deref(), Some("user_interrupt"));
+        assert_eq!(turns[0].tool_calls.len(), 1);
+        let tc = &turns[0].tool_calls[0];
+        assert_eq!(tc.kind, ToolKind::ShellHook);
+        assert_eq!(tc.name, "interrupt");
+        assert_eq!(tc.output.as_deref(), Some("turn interrupted\n"));
+    }
+
     // Codex v0.132.0 (PR #23123): `codex exec resume --output-schema` produces structured
     // JSON output items. The final model response is emitted as a "structured_output"
     // response_item with a JSON object in `content`. codex-trace must capture this as the

--- a/src/components/ToolCallItem.test.tsx
+++ b/src/components/ToolCallItem.test.tsx
@@ -715,4 +715,35 @@ describe("ToolCallItem", () => {
       expect(screen.queryByText(/Blocked by sandbox/)).not.toBeInTheDocument();
     });
   });
+
+  // Codex v0.150.0 (PR #40511): new `Interrupt` HookEventName variant, plus the general
+  // requirement (issue #251) that hook events codex-trace has never seen before still
+  // render through the generic shell_hook path instead of being dropped or shown as raw JSON.
+  describe("hook events (issue #251)", () => {
+    it("renders the interrupt hook event using the generic hook name and icon", () => {
+      const { container } = render(
+        <ToolCallItem
+          tool={makeTool({ kind: "shell_hook", name: "interrupt", output: "turn interrupted\n" })}
+          expanded={true}
+          onToggle={vi.fn()}
+        />,
+      );
+      expect(screen.getByText("interrupt")).toBeInTheDocument();
+      expect(container.querySelector(".tool-call--hook")).toBeInTheDocument();
+      expect(screen.getByText("turn interrupted")).toBeInTheDocument();
+    });
+
+    it("renders an unrecognized future hook name via the same generic hook rendering", () => {
+      const { container } = render(
+        <ToolCallItem
+          tool={makeTool({ kind: "shell_hook", name: "some_future_hook_name" })}
+          expanded={false}
+          onToggle={vi.fn()}
+        />,
+      );
+      expect(screen.getByText("some_future_hook_name")).toBeInTheDocument();
+      expect(container.querySelector(".tool-call--hook")).toBeInTheDocument();
+      expect(container.querySelector(".tool-call--unknown")).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Codex v0.150.0 (PR #40511) added a new `Interrupt` variant to the `HookEventName` enum — it fires for an active top-level turn just before its interrupted-abort event, flushing the turn transcript first.

codex-trace already models hook lifecycle events generically: hook events are parsed as `shell_hook_output` event_msg entries with a free-form `hook_type` string field (established by #104 and #107), and neither the parser nor the UI matches that string against a fixed/known set of hook names. So the new `Interrupt` value already flows through the existing path unchanged — no application code needed to change.

This PR adds regression tests across the full pipeline to lock in that behavior and directly address the issue's concern that an unrecognized hook name could be dropped silently, shown as raw JSON, or error out:

- `src-tauri/src/parser/entry.rs` — a `shell_hook_output` event with `hook_type: "interrupt"` parses as a normal `event_msg` entry
- `src-tauri/src/parser/toolcall.rs` — `finalize_shell_hook` classifies `hook_type: "interrupt"` (and an arbitrary unrecognized future hook name) as `ToolKind::ShellHook`, never dropped or erroring
- `src-tauri/src/parser/turn.rs` — a full turn-building test reproducing the exact sequence from the issue: an `interrupt` hook event fires mid-turn, immediately followed by `turn_aborted`; the turn ends `Aborted` and the hook's tool call is still present in `turn.tool_calls`
- `src/components/ToolCallItem.test.tsx` — the UI renders the `interrupt` hook (and any other future unrecognized hook name) via the generic hook icon/class, not as raw JSON or an unknown-tool fallback

## Test plan

- `cargo test --manifest-path src-tauri/Cargo.toml` — 395 lib tests + 3 ACL tests pass
- `npx vitest run` — 174 frontend tests pass
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` — clean
- `npx tsc --noEmit` — clean
- `npx oxfmt` / `cargo fmt` — clean

Fixes #251
